### PR TITLE
Jupyter Notebooks for the inference-contact family use-case

### DIFF
--- a/inference-contract/MANIFEST
+++ b/inference-contract/MANIFEST
@@ -30,6 +30,7 @@ MANIFEST.in
 ./pdo/inference/scripts/__init__.py
 ./pdo/inference/scripts/guardianCLI.py
 ./pdo/inference/scripts/scripts.py
+./pdo/inference/jupyter.py
 ./scripts/gs_stop.sh
 ./scripts/gs_start.sh
 ./scripts/gs_status.sh

--- a/inference-contract/README.md
+++ b/inference-contract/README.md
@@ -107,3 +107,19 @@ the inferencing operations.
 cd $PDO_CONTRACTS_SOURCE_ROOT/inference-contract/test/
 ./script_test.sh
 ```
+
+## Jupyter Notebooks for the Inference Contract ##
+
+We provide [Jupyter Notebooks](./docs/notebooks/README.md) that can be executed
+in an interactive manner to illustrate the functionality of the inference
+contract family. The notebooks assume that the pdo services,
+pdo ledger as well the asset guardian service are running prior to executing
+notebook commands. As noted earlier, the guardian backend is the OpenVINO
+model server; the `docker run` command provided above is used to deploy the
+backend. The frontend can be deployed (on bare-metal) using the following
+command:
+
+```bash
+cd $PDO_CONTRACTS_SOURCE_ROOT/inference-contract/test/
+./guardian_frontend.sh
+```

--- a/inference-contract/docs/notebooks/.gitignore
+++ b/inference-contract/docs/notebooks/.gitignore
@@ -1,0 +1,2 @@
+instances
+skeleton

--- a/inference-contract/docs/notebooks/README.md
+++ b/inference-contract/docs/notebooks/README.md
@@ -1,0 +1,9 @@
+# Using Jupyter Labs for Inference Contracts #
+
+This directory contains sample Jupyter notebooks that can be
+used to create and interact with contract objects (or collections of
+objects) in the Inference contract family. The structure of 
+notebooks follows the pattern followed by the notebooks used to illustrate
+the exchange contracts family. Please see exchange contracts' 
+[notebooks](../exchange-contract/docs/notebooks/README.md)
+for details about installation and general structure of notebooks.

--- a/inference-contract/docs/notebooks/factories/issuer.ipynb
+++ b/inference-contract/docs/notebooks/factories/issuer.ipynb
@@ -1,0 +1,123 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "1a3c02c0-c544-4e0c-b827-955a12b88761",
+   "metadata": {},
+   "source": [
+    "# Issuer Factory\n",
+    "\n",
+    "Use this notebook to create an issuer notebook that can be used to issue assets to users."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6be77a6e-ae7b-47e4-b47c-f45d49174b02",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import pdo.exchange.jupyter as ex_jupyter\n",
+    "import IPython.display as ip_display\n",
+    "\n",
+    "ex_jupyter.load_ipython_extension(get_ipython())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cedcd8aa-0da9-4732-a0ce-d23ea9fb5097",
+   "metadata": {},
+   "source": [
+    "## Configure Issuer Information\n",
+    "\n",
+    "This section enables customization of the token that will be minted. Edit the variables in the section below as necessary.\n",
+    "\n",
+    "* identity : the identity of the token creator\n",
+    "* token_class : the name of tokens that will be generated\n",
+    "\n",
+    "Note that the notebook assumes that there is a key file for the identity of the form: `${keys}/${identity}_private.pem`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "469fcdb8-f2b5-476a-9d1a-bf823b488202",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "identity = input('Identity of the issuer: ')\n",
+    "asset_name = input('Name of the asset:')\n",
+    "asset_description = input('Description of the asset: ')\n",
+    "asset_link = input('Link to more information about the asset: ')\n",
+    "service_host = input('Service host (e.g. \"localhost\"): ')\n",
+    "notebook_directory = os.path.abspath(os.path.join(os.getcwd(), os.pardir))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ba9e357d-5455-4232-81bd-1ada00bbf983",
+   "metadata": {},
+   "source": [
+    "## Create the Issuer Notebook\n",
+    "\n",
+    "Create a new issuer notebook with the specific asset identified."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f817cb5b-c6cb-4189-8ee6-51d598a3686f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "instance_directory = os.path.join(notebook_directory, 'instances', asset_name)\n",
+    "instance_file = os.path.join(instance_directory, 'issuer.ipynb')\n",
+    "template_file = os.path.join(notebook_directory, 'templates', 'issuer.ipynb')\n",
+    "\n",
+    "if not os.path.exists(instance_file) :\n",
+    "    os.makedirs(instance_directory, exist_ok=True)\n",
+    "    \n",
+    "    instance_parameters = {\n",
+    "        'identity' : identity,\n",
+    "        'asset_name' : asset_name,\n",
+    "        'asset_description' : asset_description,\n",
+    "        'asset_link' : asset_link,\n",
+    "        'service_host' : service_host,\n",
+    "        'notebook_directory' : notebook_directory,\n",
+    "    }\n",
+    "    \n",
+    "    import papermill as pm\n",
+    "    pm.execute_notebook(\n",
+    "        template_file,\n",
+    "        instance_file,\n",
+    "        prepare_only=True,\n",
+    "        parameters=instance_parameters,\n",
+    "    )\n",
+    "instance_path = os.path.join(os.pardir, 'instances', asset_name, 'issuer.ipynb')\n",
+    "ip_display.display(ip_display.Markdown('[Issuer Notebook]({})'.format(instance_path)))"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/inference-contract/docs/notebooks/factories/token-issuer.ipynb
+++ b/inference-contract/docs/notebooks/factories/token-issuer.ipynb
@@ -1,0 +1,157 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "6f80caf7-1c92-4223-b480-4fa943371a8b",
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
+   "source": [
+    "# Token Family Factory\n",
+    "\n",
+    "This notebook simplifies the creation of an instance of a token issuer. Update the token configuration information then evaluate the notebook to create a new token issuer. That token issuer will be able to mint tokens."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "941d1c9d",
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import pdo.inference.jupyter as ex_jupyter\n",
+    "import IPython.display as ip_display\n",
+    "\n",
+    "ex_jupyter.load_ipython_extension(get_ipython())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ad963a1f-e0fe-4d1d-90f8-3583e4b54471",
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
+   "source": [
+    "## Configure Token Information\n",
+    "\n",
+    "This section enables customization of the token that will be minted. Edit the variables in the section below as necessary.\n",
+    "\n",
+    "* identity : the identity of the token creator\n",
+    "* token_class : the name of tokens that will be generated\n",
+    "\n",
+    "Note that the notebook assumes that there is a key file for the identity of the form: `${keys}/${identity}_private.pem`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "58272e84-76a3-4ec4-a11a-6d9ac0f1951f",
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": [
+     "parameters"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "identity = input('Identity of the token issuer: ')\n",
+    "token_class = input('Name of the class of tokens to issue: ')\n",
+    "service_host = input('Service host (e.g. \"localhost\"): ')\n",
+    "notebook_directory = os.path.abspath(os.path.join(os.getcwd(), os.pardir))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bdce1f1a-5626-40a9-8e8f-44af54269f91",
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
+   "source": [
+    "## Create the Token Issuer Notebook\n",
+    "\n",
+    "Create a new token issuer notebook with the specific token identified.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f8ef720a-abf3-4008-a5ef-6920bbaa005a",
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "instance_directory = os.path.join(notebook_directory, 'instances', token_class)\n",
+    "instance_file = os.path.join(instance_directory, 'issuer.ipynb')\n",
+    "template_file = os.path.join(notebook_directory, 'templates', 'token-issuer.ipynb')\n",
+    "\n",
+    "if not os.path.exists(instance_file) :\n",
+    "    os.makedirs(instance_directory, exist_ok=True)\n",
+    "    \n",
+    "    instance_parameters = {\n",
+    "        'token_owner' : identity,\n",
+    "        'token_class' : token_class,\n",
+    "        'service_host' : service_host,\n",
+    "        'notebook_directory' : notebook_directory,\n",
+    "    }\n",
+    "    \n",
+    "    import papermill as pm\n",
+    "    pm.execute_notebook(\n",
+    "        template_file,\n",
+    "        instance_file,\n",
+    "        prepare_only=True,\n",
+    "        parameters=instance_parameters,\n",
+    "    )\n",
+    "instance_path = os.path.join(os.pardir, 'instances', token_class, 'issuer.ipynb')\n",
+    "ip_display.display(ip_display.Markdown('[Token Issuer Notebook]({})'.format(instance_path)))"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/inference-contract/docs/notebooks/templates/issuer.ipynb
+++ b/inference-contract/docs/notebooks/templates/issuer.ipynb
@@ -1,0 +1,382 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "947a0493-2838-402d-b2f0-1de63a886a8b",
+   "metadata": {},
+   "source": [
+    "# Issuer Notebook\n",
+    "\n",
+    "This notebook assumes that the asset type, vetting, and issuer contract objects are all created by the same identity. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7eb5d4f5-484c-46b1-88e9-66ef232b56cf",
+   "metadata": {},
+   "source": [
+    "## Configure Issuer Information\n",
+    "\n",
+    "This section enables customization of the token. Edit the variables in the section below as necessary.\n",
+    "* identity : the identity of the creator of the asset type\n",
+    "* asset_name : the name of the asset type to be created\n",
+    "* asset_description : a description of the asset\n",
+    "* asset_link : URL for more detailed information about the asset type\n",
+    "* context_file : the name of the context file where token information is located\n",
+    "* service_host : default host where the contract objects will be created\n",
+    "\n",
+    "When this notebook is instantiated, it will generally provide default values for `identity`, `asset_name`, `service_host`, and `notebook_directory`.\n",
+    "\n",
+    "Note that the notebook assumes that there is a key file for the identity of the form\n",
+    "\n",
+    "```bash\n",
+    "${keys}/${identity}_private.pem\n",
+    "```\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1f57b531-7cb5-499e-8822-0b75a904f243",
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": [
+     "parameters"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "identity = 'user'\n",
+    "asset_name = 'asset'\n",
+    "asset_description = 'this is an asset'\n",
+    "asset_link = 'http://'\n",
+    "context_file = '${etc}/${asset_name}_context.toml'\n",
+    "service_host = 'localhost'\n",
+    "notebook_directory = '../..'"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "197249dc-682e-45a6-a94f-429ff6f0863d",
+   "metadata": {},
+   "source": [
+    "<hr style=\"border:2px solid gray\">\n",
+    "\n",
+    "## Initialize"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "fc54c90a-3347-4cee-82cd-33c060d3fdd2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import pdo.exchange.jupyter as ex_jupyter\n",
+    "import IPython.display as ip_display\n",
+    "\n",
+    "ex_jupyter.load_ipython_extension(get_ipython())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "048cc540-b72e-4d30-a779-6d31b588bb1c",
+   "metadata": {},
+   "source": [
+    "### Initialize the PDO Environment\n",
+    "\n",
+    "Initialize the PDO environment. This assumes that a functional PDO configuration is in place and that the PDO virtual environment has been activated. In particular, ensure that the groups file and eservice database have been configured correctly. This can be done most easily by running the following in a shell:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a9e4f9b9-6a46-49db-9a67-fbad9fd7dc4b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%skip True\n",
+    "%%bash -s $service_host\n",
+    "if [ ! -f $PDO_HOME/etc/$1_groups.toml ] ; then \n",
+    "    $PDO_INSTALL_ROOT/bin/pdo-shell $PDO_HOME/bin/pdo-create-service-groups.psh --service_host $1\n",
+    "fi"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "95976c78-6a14-4061-a571-c6c359a9039c",
+   "metadata": {},
+   "source": [
+    "For the most part, no modifications should be required below."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e367a313-1f79-4381-8489-24635c808832",
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "common_bindings = {\n",
+    "    'host' : service_host,\n",
+    "    'asset_name' : asset_name,\n",
+    "    'notebook' : notebook_directory,\n",
+    "}\n",
+    "\n",
+    "(state, bindings) = ex_jupyter.initialize_environment(identity, **common_bindings)\n",
+    "print('environment initialized')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ddf0c94b-7dba-4c7c-b1b7-c4cde8778717",
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
+   "source": [
+    "### Initialize the Contract Context\n",
+    "\r\n",
+    "The contract context defines the configuration for a collection of contract objects that interact with one another. By default, the context file used in this notebook is specific to theassete clasn. We need the class to ensure that all of the information necessary for theassetn itself is availabln. If you prefer to use a common context file, edit the context_file variable below.\r\n",
+    "\r\n",
+    "For the most part, no other modifications should be required."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2f53049b-5bec-48d5-9955-e39ba7a944ea",
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "asset_path = 'asset.' + asset_name\n",
+    "context_file = bindings.expand(context_file)\n",
+    "print(\"using context file {}\".format(context_file))\n",
+    "\n",
+    "context_bindings = {\n",
+    "    'asset_type.identity' : identity,\n",
+    "    'asset_type.name' : asset_name,\n",
+    "    'asset_type.description' : asset_description,\n",
+    "    'asset_type.link' : asset_link,\n",
+    "    'vetting.identity' : identity,\n",
+    "    'issuer.identity' : identity,\n",
+    "}\n",
+    "context = ex_jupyter.initialize_asset_context(\n",
+    "    state, bindings, context_file, asset_path, **context_bindings)\n",
+    "print('context initialized')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "587e5afc-6fbf-41a1-8758-4e60278bcd71",
+   "metadata": {},
+   "source": [
+    "### Create the Contracts"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a7807826-a221-44ab-9aea-78718bb7f21f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "asset_type_context = ex_jupyter.pbuilder.Context(state, asset_path + '.asset_type')\n",
+    "asset_type_save_file = ex_jupyter.pcommand.invoke_contract_cmd(\n",
+    "    ex_jupyter.ex_asset_type.cmd_create_asset_type, state, asset_type_context)\n",
+    "ex_jupyter.pbuilder.Context.SaveContextFile(state, context_file)\n",
+    "print('asset type contract in {}'.format(asset_type_save_file))\n",
+    "\n",
+    "vetting_context = ex_jupyter.pbuilder.Context(state, asset_path + '.vetting')\n",
+    "vetting_save_file = ex_jupyter.pcommand.invoke_contract_cmd(\n",
+    "    ex_jupyter.ex_vetting.cmd_create_vetting_organization, state, vetting_context)\n",
+    "ex_jupyter.pbuilder.Context.SaveContextFile(state, context_file)\n",
+    "print('vetting contract in {}'.format(vetting_save_file))\n",
+    "\n",
+    "issuer_context = ex_jupyter.pbuilder.Context(state, asset_path + '.issuer')\n",
+    "issuer_save_file = ex_jupyter.pcommand.invoke_contract_cmd(\n",
+    "    ex_jupyter.ex_issuer.cmd_create_issuer, state, issuer_context)\n",
+    "ex_jupyter.pbuilder.Context.SaveContextFile(state, context_file)\n",
+    "print('issuer contract in {}'.format(issuer_save_file))\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "31307084-3f9a-4d22-b395-5e5b61474e5b",
+   "metadata": {},
+   "source": [
+    "### Approve Authority Chain\n",
+    "\n",
+    "Once the contracts are created, we need to establish the authority relationship. All issuers must be vetted. In this case, since the contracts are all created by the same individual, establishing the authority is relatively straight forward."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2dea15c9-da55-4bc8-b234-793cfe353a84",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ex_jupyter.pcommand.invoke_contract_cmd(\n",
+    "    ex_jupyter.ex_vetting.cmd_approve_issuer, state, vetting_context,\n",
+    "    issuer=asset_path + '.issuer')\n",
+    "\n",
+    "if not issuer_context.has_key('initialized') :\n",
+    "    ex_jupyter.pcommand.invoke_contract_cmd(\n",
+    "        ex_jupyter.ex_issuer.cmd_initialize_issuer, state, issuer_context)\n",
+    "\n",
+    "    issuer_context.set('initialized', True)\n",
+    "    ex_jupyter.pbuilder.Context.SaveContextFile(state, context_file)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6939530f-ca01-4304-baa5-49b44d90dcf7",
+   "metadata": {},
+   "source": [
+    "<hr style=\"border:2px solid gray\">\n",
+    "\n",
+    "## Operate on the Contract"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d1287f9d-cc9e-4965-ba51-64200e78e2c9",
+   "metadata": {},
+   "source": [
+    "### Issue Assets\n",
+    "\n",
+    "The issue assets function can be used to issue assets to a user. There must be a public key available for the user in the file `${keys}/${user}_public.pem`. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "717013cf-663c-4d34-bf66-f904026a864f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def issue_assets(owner, count) :\n",
+    "    try :\n",
+    "        ex_jupyter.pcommand.invoke_contract_cmd(\n",
+    "            ex_jupyter.ex_issuer.cmd_issue_assets, state, issuer_context,\n",
+    "            owner=owner, count=count)\n",
+    "    except ValueError as v :\n",
+    "        print(\"assets have already been issued to {}\".format(owner))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "263a64b4-27b9-494e-a211-ea01b60a702c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%skip True\n",
+    "issue_assets('user1', 50)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fe73b266-3901-4998-b0d6-d1b269e9feaf",
+   "metadata": {},
+   "source": [
+    "<hr style=\"border:2px solid gray\">\n",
+    "\n",
+    "## Contract Metadata"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a06d1ca8-34a0-4b83-8810-15704de18850",
+   "metadata": {
+    "papermill": {},
+    "tags": []
+   },
+   "source": [
+    "### Contract Save Files\n",
+    "\n",
+    "This notebook contains three contract files. Detailed information about the contracts can be found below."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "479c397c-542f-4bf0-8afc-04d4eadfc8b9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%skip True\n",
+    "contract_files = {\n",
+    "    'asset_type' : asset_type_save_file,\n",
+    "    'vetting' : vetting_save_file,\n",
+    "    'issuer' : issuer_save_file,\n",
+    "}\n",
+    "\n",
+    "for k, f in contract_files.items() :\n",
+    "    ip_display.display(ip_display.JSON(root=k, filename=os.path.join(bindings.expand('${save}'), f)))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3891c405-e891-4e83-a05c-501502b96d62",
+   "metadata": {},
+   "source": [
+    "### Contract Context"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1e307c5b-27ed-4786-b995-d9d66a3dbe6b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%skip True\n",
+    "# ip_display.display(ip_display.JSON(data=context.context, root='context'))\n",
+    "ip_display.display(context.context)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/inference-contract/docs/notebooks/templates/token-issuer.ipynb
+++ b/inference-contract/docs/notebooks/templates/token-issuer.ipynb
@@ -1,0 +1,404 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "6f80caf7-1c92-4223-b480-4fa943371a8b",
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
+   "source": [
+    "# Token Issuer Notebook\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ad963a1f-e0fe-4d1d-90f8-3583e4b54471",
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
+   "source": [
+    "## Configure Token Information\n",
+    "\n",
+    "This section enables customization of the token that will be minted. Edit the variables in the section below as necessary.\n",
+    "\n",
+    "* identity : the identity of the token creator\n",
+    "* service_host : the host for the eservice where tokens will be minted, this will use the default service group\n",
+    "* token_class : the name of tokens that will be generated, this is only used to simplify local access (e.g. context file name)\n",
+    "* token_description : a description of the asset associated with the minted tokens\n",
+    "* token_metadata : additional information about the token\n",
+    "* count : the number of tokens to mint for the asset\n",
+    "\n",
+    "Note that the notebook assumes that there is a key file for the identity of the form: `${keys}/${identity}_private.pem`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "58272e84-76a3-4ec4-a11a-6d9ac0f1951f",
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": [
+     "parameters"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "token_owner = 'user1'\n",
+    "token_class = 'mytoken'\n",
+    "token_description = 'this is my token'\n",
+    "token_metadata = 'created by {}'.format(token_owner)\n",
+    "count = 1\n",
+    "service_host = 'localhost'\n",
+    "notebook_directory = '../..'"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "60ff8a17-9ce8-4014-a311-2a746b0a3964",
+   "metadata": {},
+   "source": [
+    "<hr style=\"border:2px solid gray\">\n",
+    "\n",
+    "## Initialize"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "941d1c9d",
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import pdo.inference.jupyter as ex_jupyter\n",
+    "import IPython.display as ip_display\n",
+    "\n",
+    "ex_jupyter.load_ipython_extension(get_ipython())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "10857518-fd15-4d1b-af7c-334e6976934c",
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
+   "source": [
+    "### Initialize the PDO Environment\n",
+    "\n",
+    "Initialize the PDO environment. This assumes that a functional PDO configuration is in place and that the PDO virtual environment has been activated. In particular, ensure that the groups file and eservice database have been configured correctly. If you do not have a service groups configuration, you can create it for a single service host by running the following:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2be38059-c3d2-4c73-9a87-e419674d5eca",
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "%%skip True\n",
+    "%%bash -s $service_host\n",
+    "if [ ! -f $PDO_HOME/etc/$1_groups.toml ] ; then \n",
+    "    $PDO_INSTALL_ROOT/bin/pdo-shell $PDO_HOME/bin/pdo-create-service-groups.psh --service_host $1\n",
+    "fi"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7eae8c51-fa6d-46b7-a686-6fa30df313b0",
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
+   "source": [
+    "For the most part, no modifications should be require below."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "93a3cca3-efa2-42eb-ac67-78fa7a629c7d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "common_bindings = {\n",
+    "    'host' : service_host,\n",
+    "    'token_owner' : token_owner,\n",
+    "    'token_class' : token_class,\n",
+    "}\n",
+    "\n",
+    "(state, bindings) = ex_jupyter.initialize_environment(token_owner, **common_bindings)\n",
+    "print('environment initialized')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d2993293-a8a6-48aa-94ac-9b69dcdcad6f",
+   "metadata": {},
+   "source": [
+    "### Initialize the Contract Context\n",
+    "\n",
+    "The contract context defines the configuration for a collection of contract objects that interact with one another. By default, the context file used in this notebook is specific to the token. If you prefer to use a common context file, edit the `context_file` variable below.\n",
+    "\n",
+    "For the most part, no other modifications should be required."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7d4751a3-a33b-41db-a326-2bf694e0f8c3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "token_path = 'token.' + token_class\n",
+    "context_file = bindings.expand('${etc}/${token_class}_context.toml')\n",
+    "print(\"using context file {}\".format(context_file))\n",
+    "\n",
+    "context_bindings = {\n",
+    "    'asset_type.identity' : token_owner,\n",
+    "    'vetting.identity' : token_owner,\n",
+    "    'guardian.identity' : token_owner,\n",
+    "    'token_issuer.identity' : token_owner,\n",
+    "    'token_issuer.count' : count,\n",
+    "    'token_issuer.description' : token_description,\n",
+    "    'token_issuer.token_metadata.opaque' : token_metadata,\n",
+    "    'token_object.identity' : token_owner,\n",
+    "    'guardian.url' : 'http://' + service_host + ':7900'\n",
+    "}\n",
+    "\n",
+    "context = ex_jupyter.initialize_token_context(state, bindings, context_file, token_path, **context_bindings)\n",
+    "ex_jupyter.pbuilder.Context.SaveContextFile(state, context_file)\n",
+    "print('context initialized')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "17cfa7df-70d6-401e-9e7f-0a773bb6a235",
+   "metadata": {},
+   "source": [
+    "### Create the Token Issuer Contract\n",
+    "\n",
+    "The process of creating the token issuer will also create an asset type contract object, a vetting organization contract object, and the guardian contract object. The asset type and vetting organization contract objects are principally used to complete the canonical asset interface that enables transparent value exchanges with tokens and other digital assets. \n",
+    "\n",
+    "Please ensure that guardian service webserver (both frontend and backend) is running prior to creating the token issuer contract. Please see inference-contract [documentation](../../../inference-contract//README.md) for details on how to deploy the guardian service."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cc4d937d-afa0-462c-b9f2-66c78a721577",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "token_issuer_context = ex_jupyter.pbuilder.Context(state, token_path + '.token_issuer')\n",
+    "token_issuer_save_file = token_issuer_context.get('save_file')\n",
+    "if not token_issuer_save_file :\n",
+    "    token_issuer_save_file = ex_jupyter.pcommand.invoke_contract_cmd(\n",
+    "        ex_jupyter.ex_token_issuer.cmd_create_token_issuer, state, token_issuer_context)\n",
+    "    ex_jupyter.pbuilder.Context.SaveContextFile(state, context_file)\n",
+    "print('token issuer contract in {}'.format(token_issuer_save_file))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "34da911b-a59a-4c21-a0f8-d1c89c848ded",
+   "metadata": {},
+   "source": [
+    "<hr style=\"border:2px solid gray\">\n",
+    "\n",
+    "## Operate on the Contract"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "21998db2-51a8-4f2c-a841-1028cfc0b2dc",
+   "metadata": {},
+   "source": [
+    "### Mint the Tokens"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f54a589c-3965-4d71-a6a9-09e6dcf9829a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "token_object_context = ex_jupyter.pbuilder.Context(state, token_path + '.token_object')\n",
+    "\n",
+    "minted_token_save_files = ex_jupyter.pcommand.invoke_contract_cmd(\n",
+    "    ex_jupyter.inference_token_object.cmd_mint_tokens, state, token_object_context)\n",
+    "ex_jupyter.pbuilder.Context.SaveContextFile(state, context_file)\n",
+    "\n",
+    "minted_token_contexts = []\n",
+    "for token_index in range(1, len(minted_token_save_files)+1) :\n",
+    "    minted_token_contexts += [ token_object_context.get_context('token_{}'.format(token_index)) ]\n",
+    "    \n",
+    "print(\"{} tokens minted\".format(len(minted_token_save_files)))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bdce1f1a-5626-40a9-8e8f-44af54269f91",
+   "metadata": {},
+   "source": [
+    "### Create Token Notebooks\n",
+    "\n",
+    "Create a token notebook for each of the minted tokens."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f8ef720a-abf3-4008-a5ef-6920bbaa005a",
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "%%skip True\n",
+    "\n",
+    "import os\n",
+    "import papermill as pm\n",
+    "\n",
+    "instance_directory = os.path.join(notebook_directory, 'instances', token_class)\n",
+    "template_file = os.path.join(notebook_directory, 'templates', 'token.ipynb')\n",
+    "\n",
+    "os.makedirs(instance_directory, exist_ok=True)\n",
+    "\n",
+    "instance_parameters = {\n",
+    "    'token_owner' : token_owner,\n",
+    "    'token_class' : token_class,\n",
+    "    'context_file' : context_file,\n",
+    "    'service_host' : service_host,\n",
+    "}\n",
+    "\n",
+    "for token_context in minted_token_contexts :\n",
+    "    instance_parameters['token_path'] = token_context.path\n",
+    "    instance_parameters['token_name'] = token_context.path.split('.')[-1]\n",
+    "    instance_file = os.path.join(instance_directory, instance_parameters['token_name'] + '.ipynb')\n",
+    "    if not os.path.exists(instance_file) :\n",
+    "        pm.execute_notebook(\n",
+    "            template_file,\n",
+    "            instance_file,\n",
+    "            prepare_only=True,\n",
+    "            parameters=instance_parameters,\n",
+    "        )\n",
+    "    instance_path = os.path.basename(instance_file)\n",
+    "    ip_display.display(ip_display.Markdown('[{}]({})'.format(token_context.path, instance_path)))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ce76c499-a2d8-4348-a8c5-a44d980d8551",
+   "metadata": {},
+   "source": [
+    "<hr style=\"border:2px solid gray\">\n",
+    "\n",
+    "## Contract Metadata"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8f5a7eb3-9879-4ae5-a5d9-ed54ebde8642",
+   "metadata": {},
+   "source": [
+    "### Contract Save Files\n",
+    "\n",
+    "This notebook contains three contract files. Detailed information about the contracts can be found below."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "73f7d8b4-55a6-4f82-902e-b2fb891acb06",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%skip True\n",
+    "contract_files = {\n",
+    "    'asset_type' : context.get('asset_type.save_file'),\n",
+    "    'vetting' : context.get('vetting.save_file'),\n",
+    "    'token_issuer' : token_issuer_context.get('save_file'),\n",
+    "}\n",
+    "\n",
+    "for k, f in contract_files.items() :\n",
+    "    ip_display.display(ip_display.JSON(root=k, filename=os.path.join(bindings.expand('${save}'), f)))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4485d90f-2936-45a0-b988-c2c6d0af124d",
+   "metadata": {},
+   "source": [
+    "### Contract Context"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "612a5cc5-2bc6-41b1-b7e0-3c17f1bc3f3f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%skip True\n",
+    "# ip_display.display(ip_display.JSON(data=context.context, root='context'))\n",
+    "ip_display.display(context.context)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/inference-contract/docs/notebooks/templates/token.ipynb
+++ b/inference-contract/docs/notebooks/templates/token.ipynb
@@ -1,0 +1,389 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "cdaeb4db-09ed-4802-b97a-8009abe70062",
+   "metadata": {},
+   "source": [
+    "# Notebook to Invoke Token Operations"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "70a8e814-1692-41e9-a701-d0c718b47453",
+   "metadata": {},
+   "source": [
+    "## Configure Token Information\n",
+    "\n",
+    "This section enables customization of the token. Edit the variables in the section below as necessary.\n",
+    "* token_owner : the identity of the token owner\n",
+    "* token_class : the name of the class of tokens that was minted\n",
+    "* token_name : the name of the specific token that was minted\n",
+    "* token_path : the full context path to the token\n",
+    "* context_file : the name of the context file where token information is located\n",
+    "\n",
+    "Note that the notebook assumes that there is a key file for the identity of the form\n",
+    "\n",
+    "```bash\n",
+    "${keys}/${identity}_private.pem\n",
+    "```\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6733f6d6-bfee-4aeb-b17b-55289dde4043",
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": [
+     "parameters"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "token_owner = 'user1'\n",
+    "token_class = 'mytoken'\n",
+    "token_name = 'token_1'\n",
+    "token_path = 'token.${token_class}.token_object.${token_name}'\n",
+    "context_file = '${etc}/${token_class}_context.toml'\n",
+    "service_host = 'localhost'"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0955cdb9-4b8a-4de1-b64a-d466c4c25198",
+   "metadata": {},
+   "source": [
+    "<hr style=\"border:2px solid gray\">\n",
+    "\n",
+    "## Initialize"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b947ea51-bbbb-46b8-8d8e-b3c0894ee693",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import pdo.inference.jupyter as ex_jupyter\n",
+    "import IPython.display as ip_display\n",
+    "\n",
+    "ex_jupyter.load_ipython_extension(get_ipython())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3df03587-d7ec-4341-a3d3-275a893d769e",
+   "metadata": {},
+   "source": [
+    "### Initialize the PDO Environment\n",
+    "\n",
+    "Initialize the PDO environment. This assumes that a functional PDO configuration is in place and that the PDO virtual environment has been activated. In particular, ensure that the groups file and eservice database have been configured correctly. This can be done most easily by running the following in a shell:\n",
+    "\n",
+    "`$PDO_HOME/bin/pdo-create-service-groups.psh --service_host <service_host>`\n",
+    "\n",
+    "For the most part, no modifications should be required below."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "47728fa6-021e-4344-ab5c-29391b7b7f92",
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "common_bindings = {\n",
+    "    'host' : service_host,\n",
+    "    'token_owner' : token_owner,\n",
+    "    'token_class' : token_class,\n",
+    "    'token_name' : token_name,\n",
+    "}\n",
+    "\n",
+    "(state, bindings) = ex_jupyter.initialize_environment(token_owner, **common_bindings)\n",
+    "print('environment initialized')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f866c5e7-ccdb-4530-9f3f-c3afaa4c52a9",
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
+   "source": [
+    "### Initialize the Contract Context\n",
+    "\n",
+    "The contract context defines the configuration for a collection of contract objects that interact with one another. By default, the context file used in this notebook is specific to the toke class used to mint the token. We need the class to ensure that all of the information necessary for the token itself is availablen. If you prefer to use a common context file, edit the context_file variable below.\n",
+    "\n",
+    "For the most part, no other modifications should be required."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "792db38f-d0c5-4e94-a6e4-b2aae1aa6a2e",
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "token_class_path = 'token.' + token_class\n",
+    "context_file = bindings.expand(context_file)\n",
+    "print(\"using context file {}\".format(context_file))\n",
+    "\n",
+    "context = ex_jupyter.initialize_token_context(state, bindings, context_file, token_class_path)\n",
+    "print('context initialized')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6f17ed88-ef39-4f61-aa01-3c8386215aa6",
+   "metadata": {},
+   "source": [
+    "<hr style=\"border:2px solid gray\">\n",
+    "\n",
+    "## Operate on the Contract"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6d86c951-3d6e-4765-8ba0-1b5bb7ede4bd",
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "token_context = ex_jupyter.pbuilder.Context(state, token_path)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "392de557-d7e9-4e81-bf58-5a7b6eb6f208",
+   "metadata": {},
+   "source": [
+    "### Invoke Inference Operation\n",
+    "\n",
+    "The model is an image classfication model. Use the following cell to provide input to the classification oepration. Current token object policy simply checks ownership of the token. There are no additional policy checks in this example. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "585d4a40",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "image_name = input('Name of the image file')\n",
+    "path = input('Path on disk where the image is located')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0af2b02a-8d26-4e40-8b13-477609964963",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "inference_result = ex_jupyter.pcommand.invoke_contract_cmd(ex_jupyter.inference_token_object.cmd_do_inference, \n",
+    "    state, token_context, image=image_name, search_path=[path])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "39e8c51b",
+   "metadata": {},
+   "source": [
+    "### Transfer Ownership to a New User\n",
+    "\n",
+    "User1 now transfers ownership of the token object (and hence its capabilities) to a new user. Note that the notebook assumes that user 1 knows the public key of the new user, and is located at  `${keys}/`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "54cfdb62",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "new_user_identity = input('Name of the new User')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e5837f9b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ex_jupyter.pcommand.invoke_contract_cmd(ex_jupyter.inference_token_object.cmd_transfer_assets, \n",
+    "    state, token_context, new_owner=new_user_identity)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "46c40608",
+   "metadata": {},
+   "source": [
+    "### Test Ownership\n",
+    "\n",
+    "Let's ensure that user1 can no longer perform operations on the asset. The following asset usage command should fail:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2dde0969",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "inference_result = ex_jupyter.pcommand.invoke_contract_cmd(ex_jupyter.inference_token_object.cmd_do_inference, \n",
+    "    state, token_context, image=image_name, search_path=[path])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cd88957f",
+   "metadata": {},
+   "source": [
+    "### New User Performs Operations on the Asset\n",
+    "\n",
+    "Let's also ensure that user2 can indeed perform operations on the asset."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "77872058",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#note that in the following command, we explicitly pass the identity of the caller\n",
+    "\n",
+    "inference_result =  ex_jupyter.pcommand.invoke_contract_cmd(ex_jupyter.inference_token_object.cmd_do_inference, \n",
+    "    state, token_context, image=image_name, search_path=[path], identity='user2')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "320dbafb",
+   "metadata": {},
+   "source": [
+    "### Onwership Transfer Is Still Possible, But now done by user2!\n",
+    "\n",
+    "User2 is the current owner of the token, and can transfer asset-usage rights to a third person, say user3."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b1f32f41",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "current_owner_identity = new_user_identity #user2\n",
+    "new_owner_identity = 'user3'\n",
+    "\n",
+    "ex_jupyter.pcommand.invoke_contract_cmd(ex_jupyter.inference_token_object.cmd_transfer_assets, \n",
+    "    state, token_context, identity = current_owner_identity, new_owner=new_owner_identity)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fb962c70-02b0-4c2c-91f4-b025630c3e2d",
+   "metadata": {},
+   "source": [
+    "<hr style=\"border:2px solid gray\">\n",
+    "\n",
+    "## Contract Metadata"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "66bbc5ca-8061-4ae1-b378-4dbaeab64b6b",
+   "metadata": {},
+   "source": [
+    "### Contract Save Files"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6c3e057f-75e8-47ea-8e14-55a983b99839",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%skip True\n",
+    "contract_files = {\n",
+    "    'token' : token_context.get('save_file'),\n",
+    "}\n",
+    "\n",
+    "for k, f in contract_files.items() :\n",
+    "    ip_display.display(ip_display.JSON(root=k, filename=os.path.join(bindings.expand('${save}'), f)))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c0006ecf-50e1-4842-9565-44789ec24d46",
+   "metadata": {},
+   "source": [
+    "### Contract Context"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9052d00b-a8e9-4217-bd01-0a9f696762c4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%skip True\n",
+    "# ip_display.display(ip_display.JSON(data=context.context, root='context'))\n",
+    "ip_display.display(context.context)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/inference-contract/pdo/inference/__init__.py
+++ b/inference-contract/pdo/inference/__init__.py
@@ -1,0 +1,15 @@
+# Copyright 2024 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+__all__ = [ 'jupyter', 'plugins', 'wsgi', 'resources', 'scripts', 'common', 'model_scoring_scripts', 'operations']

--- a/inference-contract/pdo/inference/jupyter.py
+++ b/inference-contract/pdo/inference/jupyter.py
@@ -1,0 +1,246 @@
+# Copyright 2023 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import copy
+import logging
+import sys
+import types
+
+import pdo.client.builder as pbuilder
+import pdo.client.builder.command as pcommand
+import pdo.client.builder.context as pcontext
+import pdo.client.builder.contract as pcontract
+import pdo.client.builder.shell as pshell
+
+import pdo.client.commands.context as pcontext_cmd
+import pdo.client.commands.contract as pcontract_cmd
+
+import pdo.exchange.plugins.asset_type as ex_asset_type
+import pdo.exchange.plugins.exchange as ex_exchange
+import pdo.exchange.plugins.guardian as ex_guardian
+import pdo.exchange.plugins.issuer as ex_issuer
+import pdo.exchange.plugins.token_issuer as ex_token_issuer
+import pdo.exchange.plugins.token_object as ex_token_object
+import pdo.exchange.plugins.vetting as ex_vetting
+
+import pdo.inference.plugins.inference_guardian as inference_guardian
+import pdo.inference.plugins.inference_token_object as inference_token_object
+
+logger = logging.getLogger(__name__)
+
+logging.getLogger('papermill.translators').setLevel(logging.ERROR)
+
+# -----------------------------------------------------------------
+# Code based on suggestions found here:
+# https://stackoverflow.com/questions/26494747/simple-way-to-choose-which-cells-to-run-in-ipython-notebook-during-run-all
+#
+# Enable by adding this to the top of the notebook:
+# load_ipython_extension(get_ipython())
+#
+# Add to cell as:
+# %%skip True
+# %%skip False
+# %%skip <any python expression>
+# -----------------------------------------------------------------
+def skip(line, cell=None) :
+    """Skip execution of the current line/cell if line evaluates to True.
+    """
+    if eval(line):
+        return
+
+    get_ipython().run_cell(cell)
+
+def load_ipython_extension(shell):
+    """Registers the skip magic when the extension loads.
+    """
+    shell.register_magic_function(skip, 'line_cell')
+
+def unload_ipython_extension(shell):
+    """Unregister the skip magic when the extension unloads.
+    """
+    del shell.magics_manager.magics['cell']['skip']
+
+# -----------------------------------------------------------------
+# set up the general configuration
+# -----------------------------------------------------------------
+__default_configuration__ = {
+    'bind' : [],
+    'ledger' : None,                      # URL for the ledger
+    'data_dir' : None,                    # directory where data will be read/saved
+    'source_dir' : [],                    # directories to search for contract files
+    'key_dir' : [],                       # directories to search for key files
+    'service_db' : None,                  # name of the enclave service database
+    'service_groups' : [ '${etc}/${host}_groups.toml' ],                # list of service group files
+    'config' : [],                        # list of configuration files
+    'client_identity' : None,             # initial identity
+    'client_key_file' : None,             # key file associated with the identity
+    'verbose' : True,                     # interactive output verbosity
+    'logfile' : '__screen__',
+    'loglevel' : None,
+}
+
+def initialize_environment(identity, **kwargs) :
+    configuration = types.SimpleNamespace(**__default_configuration__)
+    configuration.client_identity = identity
+    configuration.client_key_file = '{}_private.pem'.format(identity)
+
+    # the simple version of this list(kwargs.items()) seems to generate an
+    # extra level of list when put into a namespace object
+    configuration.bind = []
+    for (k, v) in kwargs.items() :
+        configuration.bind += [(k, v)]
+
+    environment = pshell.initialize_environment(configuration)
+    if environment is None :
+        raise Exception('failed to initialize the environment')
+
+    return environment
+
+# -----------------------------------------------------------------
+# set up the context
+# -----------------------------------------------------------------
+asset_type_context = {
+    'module' : 'pdo.exchange.plugins.asset_type',
+    'identity' : None,
+    'source' : '${ContractFamily.Exchange.asset_type.source}',
+    'name' : 'asset_type',
+    'description' : 'asset type',
+    'link' : 'http://',
+    'eservice_group' : 'default',
+    'pservice_group' : 'default',
+    'sservice_group' : 'default',
+}
+
+vetting_context = {
+    'module' : 'pdo.exchange.plugins.vetting',
+    'identity' : None,
+    'source' : '${ContractFamily.Exchange.vetting.source}',
+    'asset_type_context' : '@{..asset_type}',
+    'eservice_group' : 'default',
+    'pservice_group' : 'default',
+    'sservice_group' : 'default',
+}
+
+issuer_context = {
+    'module' : 'pdo.exchange.plugins.issuer',
+    'identity' : None,
+    'source' : '${ContractFamily.Exchange.issuer.source}',
+    'asset_type_context' : '@{..asset_type}',
+    'vetting_context' : '@{..vetting}',
+    'eservice_group' : 'default',
+    'pservice_group' : 'default',
+    'sservice_group' : 'default',
+}
+
+guardian_context = {
+    'module' : 'pdo.inference.plugins.inference_guardian',
+    'identity' : '${..token_issuer.identity}',
+    'token_issuer_context' : '@{..token_issuer}',
+    'service_only' : True,
+    'url' : 'http://localhost:7900',
+}
+
+token_issuer_context = {
+    'module' : 'pdo.exchange.plugins.token_issuer',
+    'identity' : None,
+    'source' : '${ContractFamily.Exchange.token_issuer.source}',
+    'token_object_context' : '@{..token_object}',
+    'vetting_context' : '@{..vetting}',
+    'guardian_context' : '@{..guardian}',
+    'description' : 'issuer for token',
+    'token_metadata' : {
+        'opaque' : '',
+    },
+    'count' : 10,
+    'eservice_group' : 'default',
+    'pservice_group' : 'default',
+    'sservice_group' : 'default',
+}
+
+token_object_context = {
+    'module' : 'pdo.inference.plugins.inference_token_object',
+    'identity' : '${..token_issuer.identity}',
+    'source' : '${ContractFamily.inference.token_object.source}',
+    'token_issuer_context' : '@{..token_issuer}',
+    'data_guardian_context' : '@{..guardian}',
+    'eservice_group' : 'default',
+    'pservice_group' : 'default',
+    'sservice_group' : 'default',
+}
+
+order_context = {
+    'module' : 'pdo.exchange.plugins.exchange',
+    'identity' : None,
+    'source' : '${ContractFamily.Exchange.exchange.source}',
+    'offer' : {
+        'issuer_context' : '@{context.${offer_issuer}}',
+        'count' : 1,
+    },
+    'request' : {
+        'issuer_context' : '@{context.${request_issuer}}',
+        'count' : 1,
+    },
+    'eservice_group' : 'default',
+    'pservice_group' : 'default',
+    'sservice_group' : 'default',
+}
+
+context_map = {
+    'asset_type' : asset_type_context,
+    'vetting' : vetting_context,
+    'issuer' : issuer_context,
+    'guardian' : guardian_context,
+    'token_issuer' : token_issuer_context,
+    'token_object' : token_object_context,
+    'order' : order_context,
+}
+
+# -----------------------------------------------------------------
+# initialize_context
+# -----------------------------------------------------------------
+def initialize_context(state, bindings, context_file, prefix, contexts, **kwargs) :
+    """Load context from a file and instantiate context templates
+    """
+
+    # attempt to load the context from the context file
+    try :
+        pbuilder.Context.LoadContextFile(state, bindings, context_file)
+    except :
+        logger.warning('failed to load context from {}'.format(context_file))
+
+    context =  pbuilder.Context(state, prefix)
+    if context.has_key('initialized') :
+        return context
+
+    for c in contexts :
+        context.set(c, copy.deepcopy(context_map[c]))
+
+    for (k, v) in kwargs.items() :
+        context.set(k, v)
+
+    context.set('initialized', True)
+    return context
+
+def initialize_asset_context(state, bindings, context_file, prefix, **kwargs) :
+    contexts = ['asset_type', 'vetting', 'issuer']
+    return initialize_context(state, bindings, context_file, prefix, contexts, **kwargs)
+
+def initialize_token_context(state, bindings, context_file, prefix, **kwargs) :
+    contexts = ['asset_type', 'vetting', 'guardian', 'token_issuer', 'token_object']
+    return initialize_context(state, bindings, context_file, prefix, contexts, **kwargs)
+
+def initialize_order_context(state, bindings, context_file, prefix, **kwargs) :
+    contexts = ['order']
+    return initialize_context(state, bindings, context_file, prefix, contexts, **kwargs)


### PR DESCRIPTION
This PR provides Jupyter Notebooks to interact with the contracts in the inference-contact family. The Notebooks' structure, installation, execution patterns are same as those used by the Noteboks provided for the Exchange contract family. Please note that the guardian service (both frontend and backend) must be started prior to executing the notebooks. Please see inference-contract/README.md for instructions. 