### PR TITLE
Fix a problem with cleaning python egg directories

### DIFF
--- a/cmake/Python.cmake
+++ b/cmake/Python.cmake
@@ -28,7 +28,7 @@ FUNCTION(BUILD_WHEEL contract)
   # adding the build and egg-info directories to the output means that
   # they will be cleaned up with the global clean target
   ADD_CUSTOM_COMMAND(
-    OUTPUT ${WHEEL_FILE} ${SOURCE}/build ${SOURCE}/pdo_exchange.egg-info
+    OUTPUT ${WHEEL_FILE} ${SOURCE}/build ${SOURCE}/pdo_${contract}.egg-info
     COMMAND ${PYTHON}
     ARGS -m build --wheel --outdir ${WHEEL_PATH}
     WORKING_DIRECTORY ${SOURCE}


### PR DESCRIPTION
Fix a bug in the python cmake library that resulted in just the exchange folder being cleaned correctly.

Mea culpa.