### PR TITLE
Revert the cmake dependency to ensure that ubuntu 20.04 continues to be supported

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-CMAKE_MINIMUM_REQUIRED(VERSION 3.17 FATAL_ERROR)
+CMAKE_MINIMUM_REQUIRED(VERSION 3.16 FATAL_ERROR)
 
 PROJECT(pdo-contracts)
 LIST(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake")


### PR DESCRIPTION
Most client development now assumes ubuntu 22.04. However we want to continue to support 20.04 for the moment. This will make cmake work with ubuntu 20.04 default cmake version.