### PR TITLE
Update tests for the service groups database

### DIFF
--- a/cmake/Jupyter.cmake
+++ b/cmake/Jupyter.cmake
@@ -14,6 +14,9 @@
 
 
 SET(JUPYTEXT "${PDO_INSTALL_ROOT}/bin/jupytext" CACHE STRING "Path to the Jupytext command")
+IF(NOT EXISTS ${JUPYTEXT})
+  MESSAGE(FATAL_ERROR "${JUPYTEXT} not found; please install with '${PDO_INSTALL_ROOT}/bin/pip install jupytext'")
+ENDIF()
 
 FUNCTION(CONVERT_JUPYTEXT NOTEBOOKS)
   SET(RESULT)

--- a/digital-asset-contract/test/run_tests.sh
+++ b/digital-asset-contract/test/run_tests.sh
@@ -26,8 +26,7 @@ source ${PDO_HOME}/bin/lib/common.sh
 check_python_version
 
 if ! command -v pdo-shell &> /dev/null ; then
-    yell unable to locate pdo-shell
-    exit 1
+    die unable to locate pdo-shell
 fi
 
 # -----------------------------------------------------------------
@@ -72,14 +71,21 @@ while true ; do
     esac
 done
 
-F_SERVICE_GROUPS_FILE=${SOURCE_ROOT}/test/${F_SERVICE_HOST}_groups.toml
+F_SERVICE_SITE_FILE=${PDO_HOME}/etc/sites/${F_SERVICE_HOST}.toml
+if [ ! -f ${F_SERVICE_SITE_FILE} ] ; then
+    die unable to locate the service information file ${F_SERVICE_SITE_FILE}; \
+        please copy the site.toml file from the service host
+fi
+
+F_SERVICE_GROUPS_DB_FILE=${SOURCE_ROOT}/test/${F_SERVICE_HOST}_groups_db
 F_SERVICE_DB_FILE=${SOURCE_ROOT}/test/${F_SERVICE_HOST}_db
 
 _COMMON_=("--logfile ${F_LOGFILE}" "--loglevel ${F_LOGLEVEL}")
 _COMMON_+=("--ledger ${F_LEDGER_URL}")
-_COMMON_+=("--bind service_host ${F_SERVICE_HOST}")
-_COMMON_+=("--service-groups ${F_SERVICE_GROUPS_FILE}")
+_COMMON_+=("--groups-db ${F_SERVICE_GROUPS_DB_FILE}")
 _COMMON_+=("--service-db ${F_SERVICE_DB_FILE}")
+SHORT_OPTS=${_COMMON_[@]}
+
 _COMMON_+=("--context-file ${F_CONTEXT_FILE}")
 OPTS=${_COMMON_[@]}
 
@@ -114,7 +120,7 @@ fi
 
 # -----------------------------------------------------------------
 function cleanup {
-    rm -f ${F_SERVICE_GROUPS_FILE}
+    rm -f ${F_SERVICE_GROUPS_DB_FILE} ${F_SERVICE_GROUPS_DB_FILE}-lock
     rm -f ${F_SERVICE_DB_FILE} ${F_SERVICE_DB_FILE}-lock
     rm -f ${F_CONTEXT_FILE}
     for key_file in ${F_KEY_FILES[@]} ; do
@@ -125,13 +131,18 @@ function cleanup {
 trap cleanup EXIT
 
 # -----------------------------------------------------------------
-# reset the eservice database file for the test and create the groups
+# create the service and groups databases from a site file; the site
+# file is assumed to exist in ${PDO_HOME}/etc/sites/${SERVICE_HOST}.toml
+#
+# by default, the groups will include all available services from the
+# service host
 # -----------------------------------------------------------------
 yell create the service and groups database for host ${F_SERVICE_HOST}
-try ${PDO_HOME}/bin/pdo-create-service-groups.psh \
-    --service-db ${F_SERVICE_DB_FILE} \
-    --bind service_host ${F_SERVICE_HOST} \
-    --bind group_file ${F_SERVICE_GROUPS_FILE}
+try pdo-service-db import ${SHORT_OPTS} --file ${F_SERVICE_SITE_FILE}
+try pdo-eservice create_from_site ${SHORT_OPTS} --file ${F_SERVICE_SITE_FILE} --group default
+try pdo-pservice create_from_site ${SHORT_OPTS} --file ${F_SERVICE_SITE_FILE} --group default
+try pdo-sservice create_from_site ${SHORT_OPTS} --file ${F_SERVICE_SITE_FILE} --group default \
+             --replicas 1 --duration 60
 
 # -----------------------------------------------------------------
 # -----------------------------------------------------------------

--- a/docker/test_jupyter.yaml
+++ b/docker/test_jupyter.yaml
@@ -69,4 +69,4 @@ services:
     network_mode: "host"
     volumes:
       - ./xfer/:/project/pdo/xfer/
-    entrypoint: /project/pdo/tools/run_jupyter_tests.sh -i localhost -l http://127.0.0.1:6600
+    entrypoint: /project/pdo/tools/run_jupyter_tests.sh -i localhost -l http://127.0.0.1:6600 -s localhost

--- a/docker/tools/run_guardian_tests.sh
+++ b/docker/tools/run_guardian_tests.sh
@@ -75,18 +75,13 @@ while [ ! -f ${XFER_DIR}/ccf/keys/networkcert.pem ]; do
 done
 try cp ${XFER_DIR}/ccf/keys/networkcert.pem ${PDO_LEDGER_KEY_ROOT}/
 
-# for now the site.toml is just a way to notify
-# that the services are running; in the future
-# the client should be able to incorporate this
-# file and begin to use the information, again
-# in theory this should be taken care of by the
-# health checks in the docker compose configuration
+# site.toml is a way to notify that the services are running
+# the guardian service does not require any site specific configuration
+# so the services and groups are not created
 while [ ! -f ${XFER_DIR}/services/etc/site.toml ]; do
     say "waiting for site configuration"
     sleep 5
 done
-
-try cp ${XFER_DIR}/services/etc/site.toml ${PDO_HOME}/etc/site.toml
 
 # -----------------------------------------------------------------
 function cleanup {

--- a/docker/tools/run_jupyter_tests.sh
+++ b/docker/tools/run_jupyter_tests.sh
@@ -22,12 +22,13 @@ source ${PDO_HOME}/bin/lib/common.sh
 # Process command line arguments
 # -----------------------------------------------------------------
 F_LEDGER_URL=
+F_SERVICE_HOST=
 F_INTERFACE=localhost
 F_PORT=8888
 
-F_USAGE='-i|--interface [hostname] -1|--ledger [url] -p|--port [port]'
-SHORT_OPTS='i:l:p:'
-LONG_OPTS='interface:,ledger:,port:'
+F_USAGE='-i|--interface [hostname] -1|--ledger [url] -p|--port [port] -s|--service-host [hostname]'
+SHORT_OPTS='i:l:p:s:'
+LONG_OPTS='interface:,ledger:,port:,service-host:'
 
 TEMP=$(getopt -o ${SHORT_OPTS} --long ${LONG_OPTS} -n "${SCRIPT_NAME}" -- "$@")
 if [ $? != 0 ] ; then echo "Usage: ${SCRIPT_NAME} ${F_USAGE}" >&2 ; exit 1 ; fi
@@ -38,11 +39,16 @@ while true ; do
         -i|--interface) F_INTERFACE="$2" ; shift 2 ;;
         -l|--ledger) F_LEDGER_URL="$2" ; shift 2 ;;
         -p|--port) F_PORT="$2" ; shift 2 ;;
+        -s|--service-host) F_SERVICE_HOST="$2" ; shift 2 ;;
         --help) echo "Usage: ${SCRIPT_NAME} ${F_USAGE}"; exit 0 ;;
     	--) shift ; break ;;
     	*) echo "Internal error!" ; exit 1 ;;
     esac
 done
+
+if [ -z "${F_SERVICE_HOST}" ]; then
+    die Missing required parameter: service-host
+fi
 
 if [ -z "${F_LEDGER_URL}" ]; then
     die Missing required parameter: ledger
@@ -51,13 +57,18 @@ fi
 # The client only uses PDO_HOSTNAME to create the initial configuration
 # file. Since the notebook will override this for each operation, we
 # just leave it set to localhost
-export PDO_HOSTNAME=localhost
+export PDO_HOSTNAME=${F_SERVICE_HOST}
 export PDO_LEDGER_URL=${F_LEDGER_URL}
 
 export no_proxy=$PDO_HOSTNAME,$no_proxy
 export NO_PROXY=$PDO_HOSTNAME,$NO_PROXY
 
 check_pdo_runtime_env
+
+# -----------------------------------------------------------------
+# activate the virtual environment
+# -----------------------------------------------------------------
+. ${PDO_INSTALL_ROOT}/bin/activate
 
 # -----------------------------------------------------------------
 yell copy ledger keys
@@ -74,18 +85,23 @@ while [ ! -f ${XFER_DIR}/ccf/keys/networkcert.pem ]; do
 done
 try cp ${XFER_DIR}/ccf/keys/networkcert.pem ${PDO_LEDGER_KEY_ROOT}/
 
-# for now the site.toml is just a way to notify
-# that the services are running; in the future
-# the client should be able to incorporate this
-# file and begin to use the information, again
-# in theory this should be taken care of by the
-# health checks in the docker compose configuration
+# site.toml is a way to notify that the services are running;
+# in addition, the client uses the information to load the
+# services and groups database; we create an initial
+# default database from this information
+F_SERVICE_SITE_FILE=${PDO_HOME}/etc/sites/${F_SERVICE_HOST}.toml
+mkdir -p $(dirname ${F_SERVICE_SITE_FILE})
+
 while [ ! -f ${XFER_DIR}/services/etc/site.toml ]; do
     say "waiting for site configuration"
     sleep 5
 done
 
-try cp ${XFER_DIR}/services/etc/site.toml ${PDO_HOME}/etc/site.toml
+try cp ${XFER_DIR}/services/etc/site.toml ${F_SERVICE_SITE_FILE}
+try pdo-service-db import --file ${F_SERVICE_SITE_FILE}
+try pdo-eservice create_from_site --file ${F_SERVICE_SITE_FILE} --group default
+try pdo-pservice create_from_site --file ${F_SERVICE_SITE_FILE} --group default
+try pdo-sservice create_from_site --file ${F_SERVICE_SITE_FILE} --group default --replicas 1 --duration 60
 
 # -----------------------------------------------------------------
 # Handle the configuration of the services
@@ -97,8 +113,6 @@ try ${PDO_INSTALL_ROOT}/bin/pdo-configure-users -t ${PDO_SOURCE_ROOT}/build/temp
 # -----------------------------------------------------------------
 yell start the jupyter server
 # -----------------------------------------------------------------
-. ${PDO_INSTALL_ROOT}/bin/activate
-
 export PDO_JUPYTER_ROOT=${PDO_INSTALL_ROOT}/opt/pdo/notebooks
 
 cd ${PDO_JUPYTER_ROOT}

--- a/docs/notebooks/documents/getting_started.md
+++ b/docs/notebooks/documents/getting_started.md
@@ -28,19 +28,17 @@ Assumptions:
 3. Create a service group configuration
 
 
-## Simplified configuration
+## Site configuration
 
-If you are running the PDO services in the common test configuration
-(e.g. with 5 provisioning services, 5 enclave service, and 5 storage
-services all running on the same host, you can create all of the
-necessary configuration files with the command:
+In order to access services, you must add information about the
+services to the services database (see the script
+`pdo-service-db`). Further, to create new contracts it is necessary to
+create one or more groups of services that can be bound to the
+contract (see the script `pdo-groups-db`, `pdo-eservice`,
+`pdo-pservice`, and `pdo-sservice`).
 
-```
-    $ export service_host=<service hostname>
-    $ ${PDO_INSTALL_ROOT}/opt/pdo/bin/pdo-create-service-groups.psh --service_host ${service_host}
-```
-
-Use `service_host` in the notebooks that you create.
+To simplify testing, a simple configuration for local services is
+created during docker container startup.
 
 ### Create a personal configuration file
 

--- a/exchange-contract/docs/notebooks/templates/exchange_create.py
+++ b/exchange-contract/docs/notebooks/templates/exchange_create.py
@@ -61,17 +61,13 @@ pc_jupyter.load_ipython_extension(get_ipython())
 # %% [markdown]
 # ### Initialize the PDO Environment
 #
-# Initialize the PDO environment. This assumes that a functional PDO configuration is in place and that the PDO virtual environment has been activated. In particular, ensure that the groups file and eservice database have been configured correctly. This can be done most easily by running the following in a shell:
-
-# %%
-# %%skip True
-# %%bash -s $service_host
-if [ ! -f $PDO_HOME/etc/$1_groups.toml ] ; then
-    $PDO_INSTALL_ROOT/bin/pdo-shell $PDO_HOME/bin/pdo-create-service-groups.psh --service_host $1
-fi
-
-# %% [markdown]
-# In the next box we will set up the PDO client configuration. This will load any client configuration files, service group files, and service database files. Common bindings provides a means to override specific configuration variables and set variable expansion values.
+# Initialize the PDO environment. This assumes that a functional PDO configuration is in place and
+# that the PDO virtual environment has been activated. In particular, ensure that the groups file
+# and eservice database have been configured correctly.
+#
+# In the next box we will set up the PDO client configuration. This will load any client
+# configuration files, service group files, and service database files. Common bindings provides a
+# means to override specific configuration variables and set variable expansion values.
 #
 # For the most part, no modifications should be required.
 

--- a/exchange-contract/docs/notebooks/templates/exchange_import.py
+++ b/exchange-contract/docs/notebooks/templates/exchange_import.py
@@ -55,16 +55,10 @@ pc_jupyter.load_ipython_extension(get_ipython())
 # %% [markdown]
 # ### Initialize the PDO Environment
 #
-# Initialize the PDO environment. This assumes that a functional PDO configuration is in place and that the PDO virtual environment has been activated. In particular, ensure that the groups file and eservice database have been configured correctly. This can be done most easily by running the following in a shell:
-
-# %%
-# %%skip True
-# %%bash -s $service_host
-if [ ! -f $PDO_HOME/etc/$1_groups.toml ] ; then
-    $PDO_INSTALL_ROOT/bin/pdo-shell $PDO_HOME/bin/pdo-create-service-groups.psh --service_host $1
-fi
-
-# %% [markdown]
+# Initialize the PDO environment. This assumes that a functional PDO configuration is in place and
+# that the PDO virtual environment has been activated. In particular, ensure that the groups file
+# and eservice database have been configured correctly.
+#
 # For the most part, no modifications should be required below.
 
 # %%

--- a/exchange-contract/docs/notebooks/templates/issuer.py
+++ b/exchange-contract/docs/notebooks/templates/issuer.py
@@ -65,19 +65,9 @@ pc_jupyter.load_ipython_extension(get_ipython())
 #
 # Initialize the PDO environment. This assumes that a functional PDO configuration is in place and
 # that the PDO virtual environment has been activated. In particular, ensure that the groups file
-# and eservice database have been configured correctly. This can be done most easily by running the
-# following in a shell:
-
-# %%
-# %%skip True
-# %%bash -s $service_host
-if [ ! -f $PDO_HOME/etc/$1_groups.toml ] ; then
-    $PDO_INSTALL_ROOT/bin/pdo-shell $PDO_HOME/bin/pdo-create-service-groups.psh --service_host $1
-fi
-
-# %% [markdown]
+# and eservice database have been configured correctly.
+#
 # For the most part, no modifications should be required below.
-
 # %%
 common_bindings = {
     'host' : service_host,

--- a/exchange-contract/docs/notebooks/templates/token-issuer.py
+++ b/exchange-contract/docs/notebooks/templates/token-issuer.py
@@ -54,18 +54,11 @@ pc_jupyter.load_ipython_extension(get_ipython())
 # %% [markdown]
 # ### Initialize the PDO Environment
 #
-# Initialize the PDO environment. This assumes that a functional PDO configuration is in place and that the PDO virtual environment has been activated. In particular, ensure that the groups file and eservice database have been configured correctly. If you do not have a service groups configuration, you can create it for a single service host by running the following:
-
-# %%
-# %%skip True
-# %%bash -s $service_host
-if [ ! -f $PDO_HOME/etc/$1_groups.toml ] ; then
-    $PDO_INSTALL_ROOT/bin/pdo-shell $PDO_HOME/bin/pdo-create-service-groups.psh --service_host $1
-fi
-
-# %% [markdown]
-# For the most part, no modifications should be require below.
-
+# Initialize the PDO environment. This assumes that a functional PDO configuration is in place and
+# that the PDO virtual environment has been activated. In particular, ensure that the groups file
+# and eservice database have been configured correctly.
+#
+# For the most part, no modifications should be required below.
 # %%
 common_bindings = {
     'host' : service_host,

--- a/exchange-contract/docs/notebooks/templates/token.py
+++ b/exchange-contract/docs/notebooks/templates/token.py
@@ -56,12 +56,11 @@ pc_jupyter.load_ipython_extension(get_ipython())
 # %% [markdown]
 # ### Initialize the PDO Environment
 #
-# Initialize the PDO environment. This assumes that a functional PDO configuration is in place and that the PDO virtual environment has been activated. In particular, ensure that the groups file and eservice database have been configured correctly. This can be done most easily by running the following in a shell:
-#
-# `$PDO_HOME/bin/pdo-create-service-groups.psh --service_host <service_host>`
+# Initialize the PDO environment. This assumes that a functional PDO configuration is in place and
+# that the PDO virtual environment has been activated. In particular, ensure that the groups file
+# and eservice database have been configured correctly.
 #
 # For the most part, no modifications should be required below.
-
 # %%
 common_bindings = {
     'host' : service_host,

--- a/exchange-contract/scripts/init.psh
+++ b/exchange-contract/scripts/init.psh
@@ -14,9 +14,6 @@
 ## See the License for the specific language governing permissions and
 ## limitations under the License.
 
-## load the eservice and pservice groups for the site
-script -f ${home}/etc/site.psh
-
 ## load the exchange plugins
 set --conditional -s contracts -v ${home}/contracts/exchange
 set --conditional -s plugins -v ${home}/contracts/plugins/exchange

--- a/exchange-contract/test/run_tests.sh
+++ b/exchange-contract/test/run_tests.sh
@@ -26,8 +26,7 @@ source ${PDO_HOME}/bin/lib/common.sh
 check_python_version
 
 if ! command -v pdo-shell &> /dev/null ; then
-    yell unable to locate pdo-shell
-    exit 1
+    die unable to locate pdo-shell
 fi
 
 # -----------------------------------------------------------------
@@ -72,14 +71,21 @@ while true ; do
     esac
 done
 
-F_SERVICE_GROUPS_FILE=${SOURCE_ROOT}/test/${F_SERVICE_HOST}_groups.toml
+F_SERVICE_SITE_FILE=${PDO_HOME}/etc/sites/${F_SERVICE_HOST}.toml
+if [ ! -f ${F_SERVICE_SITE_FILE} ] ; then
+    die unable to locate the service information file ${F_SERVICE_SITE_FILE}; \
+        please copy the site.toml file from the service host
+fi
+
+F_SERVICE_GROUPS_DB_FILE=${SOURCE_ROOT}/test/${F_SERVICE_HOST}_groups_db
 F_SERVICE_DB_FILE=${SOURCE_ROOT}/test/${F_SERVICE_HOST}_db
 
 _COMMON_=("--logfile ${F_LOGFILE}" "--loglevel ${F_LOGLEVEL}")
 _COMMON_+=("--ledger ${F_LEDGER_URL}")
-_COMMON_+=("--bind service_host ${F_SERVICE_HOST}")
-_COMMON_+=("--service-groups ${F_SERVICE_GROUPS_FILE}")
+_COMMON_+=("--groups-db ${F_SERVICE_GROUPS_DB_FILE}")
 _COMMON_+=("--service-db ${F_SERVICE_DB_FILE}")
+SHORT_OPTS=${_COMMON_[@]}
+
 _COMMON_+=("--context-file ${F_CONTEXT_FILE}")
 OPTS=${_COMMON_[@]}
 
@@ -114,7 +120,7 @@ fi
 
 # -----------------------------------------------------------------
 function cleanup {
-    rm -f ${F_SERVICE_GROUPS_FILE}
+    rm -f ${F_SERVICE_GROUPS_DB_FILE} ${F_SERVICE_GROUPS_DB_FILE}-lock
     rm -f ${F_SERVICE_DB_FILE} ${F_SERVICE_DB_FILE}-lock
     rm -f ${F_CONTEXT_FILE}
     for key_file in ${F_KEY_FILES[@]} ; do
@@ -125,13 +131,18 @@ function cleanup {
 trap cleanup EXIT
 
 # -----------------------------------------------------------------
-# reset the eservice database file for the test and create the groups
+# create the service and groups databases from a site file; the site
+# file is assumed to exist in ${PDO_HOME}/etc/sites/${SERVICE_HOST}.toml
+#
+# by default, the groups will include all available services from the
+# service host
 # -----------------------------------------------------------------
 yell create the service and groups database for host ${F_SERVICE_HOST}
-try ${PDO_HOME}/bin/pdo-create-service-groups.psh \
-    --service-db ${F_SERVICE_DB_FILE} \
-    --bind service_host ${F_SERVICE_HOST} \
-    --bind group_file ${F_SERVICE_GROUPS_FILE}
+try pdo-service-db import ${SHORT_OPTS} --file ${F_SERVICE_SITE_FILE}
+try pdo-eservice create_from_site ${SHORT_OPTS} --file ${F_SERVICE_SITE_FILE} --group default
+try pdo-pservice create_from_site ${SHORT_OPTS} --file ${F_SERVICE_SITE_FILE} --group default
+try pdo-sservice create_from_site ${SHORT_OPTS} --file ${F_SERVICE_SITE_FILE} --group default \
+             --replicas 1 --duration 60
 
 # -----------------------------------------------------------------
 # setup the contexts that will be used later for the tests

--- a/exchange-contract/test/script_test.sh
+++ b/exchange-contract/test/script_test.sh
@@ -26,8 +26,7 @@ source ${PDO_HOME}/bin/lib/common.sh
 check_python_version
 
 if ! command -v pdo-shell &> /dev/null ; then
-    yell unable to locate pdo-shell
-    exit 1
+    die unable to locate pdo-shell
 fi
 
 # -----------------------------------------------------------------
@@ -72,14 +71,21 @@ while true ; do
     esac
 done
 
-F_SERVICE_GROUPS_FILE=${SOURCE_ROOT}/test/${F_SERVICE_HOST}_groups.toml
+F_SERVICE_SITE_FILE=${PDO_HOME}/etc/sites/${F_SERVICE_HOST}.toml
+if [ ! -f ${F_SERVICE_SITE_FILE} ] ; then
+    die unable to locate the service information file ${F_SERVICE_SITE_FILE}; \
+        please copy the site.toml file from the service host
+fi
+
+F_SERVICE_GROUPS_DB_FILE=${SOURCE_ROOT}/test/${F_SERVICE_HOST}_groups_db
 F_SERVICE_DB_FILE=${SOURCE_ROOT}/test/${F_SERVICE_HOST}_db
 
 _COMMON_=("--logfile ${F_LOGFILE}" "--loglevel ${F_LOGLEVEL}")
 _COMMON_+=("--ledger ${F_LEDGER_URL}")
-_COMMON_+=("--bind service_host ${F_SERVICE_HOST}")
-_COMMON_+=("--service-groups ${F_SERVICE_GROUPS_FILE}")
+_COMMON_+=("--groups-db ${F_SERVICE_GROUPS_DB_FILE}")
 _COMMON_+=("--service-db ${F_SERVICE_DB_FILE}")
+SHORT_OPTS=${_COMMON_[@]}
+
 _COMMON_+=("--context-file ${F_CONTEXT_FILE}")
 OPTS=${_COMMON_[@]}
 
@@ -114,7 +120,7 @@ fi
 
 # -----------------------------------------------------------------
 function cleanup {
-    rm -f ${F_SERVICE_GROUPS_FILE}
+    rm -f ${F_SERVICE_GROUPS_DB_FILE} ${F_SERVICE_GROUPS_DB_FILE}-lock
     rm -f ${F_SERVICE_DB_FILE} ${F_SERVICE_DB_FILE}-lock
     rm -f ${F_CONTEXT_FILE}
     for key_file in ${F_KEY_FILES[@]} ; do
@@ -125,13 +131,18 @@ function cleanup {
 trap cleanup EXIT
 
 # -----------------------------------------------------------------
-# reset the eservice database file for the test and create the groups
+# create the service and groups databases from a site file; the site
+# file is assumed to exist in ${PDO_HOME}/etc/sites/${SERVICE_HOST}.toml
+#
+# by default, the groups will include all available services from the
+# service host
 # -----------------------------------------------------------------
 yell create the service and groups database for host ${F_SERVICE_HOST}
-try ${PDO_HOME}/bin/pdo-create-service-groups.psh  \
-    --service-db ${F_SERVICE_DB_FILE} \
-    --bind service_host ${F_SERVICE_HOST} \
-    --bind group_file ${F_SERVICE_GROUPS_FILE}
+try pdo-service-db import ${SHORT_OPTS} --file ${F_SERVICE_SITE_FILE}
+try pdo-eservice create_from_site ${SHORT_OPTS} --file ${F_SERVICE_SITE_FILE} --group default
+try pdo-pservice create_from_site ${SHORT_OPTS} --file ${F_SERVICE_SITE_FILE} --group default
+try pdo-sservice create_from_site ${SHORT_OPTS} --file ${F_SERVICE_SITE_FILE} --group default \
+             --replicas 1 --duration 60
 
 # -----------------------------------------------------------------
 # setup the contexts that will be used later for the tests

--- a/inference-contract/test/script_test.sh
+++ b/inference-contract/test/script_test.sh
@@ -22,15 +22,12 @@
 
 # -----------------------------------------------------------------
 # -----------------------------------------------------------------
-
 source ${PDO_HOME}/bin/lib/common.sh
 check_python_version
 
 if ! command -v pdo-shell &> /dev/null ; then
-    yell unable to locate pdo-shell
-    exit 1
+    die unable to locate pdo-shell
 fi
-
 
 # -----------------------------------------------------------------
 # -----------------------------------------------------------------
@@ -76,14 +73,21 @@ while true ; do
     esac
 done
 
-F_SERVICE_GROUPS_FILE=${SOURCE_ROOT}/test/${F_SERVICE_HOST}_groups.toml
+F_SERVICE_SITE_FILE=${PDO_HOME}/etc/sites/${F_SERVICE_HOST}.toml
+if [ ! -f ${F_SERVICE_SITE_FILE} ] ; then
+    die unable to locate the service information file ${F_SERVICE_SITE_FILE}; \
+        please copy the site.toml file from the service host
+fi
+
+F_SERVICE_GROUPS_DB_FILE=${SOURCE_ROOT}/test/${F_SERVICE_HOST}_groups_db
 F_SERVICE_DB_FILE=${SOURCE_ROOT}/test/${F_SERVICE_HOST}_db
 
 _COMMON_=("--logfile ${F_LOGFILE}" "--loglevel ${F_LOGLEVEL}")
 _COMMON_+=("--ledger ${F_LEDGER_URL}")
-_COMMON_+=("--bind service_host ${F_SERVICE_HOST}")
-_COMMON_+=("--service-groups ${F_SERVICE_GROUPS_FILE}")
+_COMMON_+=("--groups-db ${F_SERVICE_GROUPS_DB_FILE}")
 _COMMON_+=("--service-db ${F_SERVICE_DB_FILE}")
+SHORT_OPTS=${_COMMON_[@]}
+
 _COMMON_+=("--context-file ${F_CONTEXT_FILE}")
 OPTS=${_COMMON_[@]}
 
@@ -127,7 +131,7 @@ fi
 
 # -----------------------------------------------------------------
 function cleanup {
-    rm -f ${F_SERVICE_GROUPS_FILE}
+    rm -f ${F_SERVICE_GROUPS_DB_FILE} ${F_SERVICE_GROUPS_DB_FILE}-lock
     rm -f ${F_SERVICE_DB_FILE} ${F_SERVICE_DB_FILE}-lock
     rm -f ${F_CONTEXT_FILE}
     for key_file in ${F_KEY_FILES[@]} ; do
@@ -159,13 +163,18 @@ try ${PDO_HOME}/contracts/inference/scripts/gs_start.sh -c -o ${PDO_HOME}/logs -
     --bind service_host ${F_SERVICE_HOST}
 
 # -----------------------------------------------------------------
-# reset the eservice database file for the test and create the groups
+# create the service and groups databases from a site file; the site
+# file is assumed to exist in ${PDO_HOME}/etc/sites/${SERVICE_HOST}.toml
+#
+# by default, the groups will include all available services from the
+# service host
 # -----------------------------------------------------------------
-yell create the service groups database for host ${F_SERVICE_HOST}
-try ${PDO_HOME}/bin/pdo-create-service-groups.psh \
-    --service-db ${F_SERVICE_DB_FILE} \
-    --bind service_host ${F_SERVICE_HOST} \
-    --bind group_file ${F_SERVICE_GROUPS_FILE}
+yell create the service and groups database for host ${F_SERVICE_HOST}
+try pdo-service-db import ${SHORT_OPTS} --file ${F_SERVICE_SITE_FILE}
+try pdo-eservice create_from_site ${SHORT_OPTS} --file ${F_SERVICE_SITE_FILE} --group default
+try pdo-pservice create_from_site ${SHORT_OPTS} --file ${F_SERVICE_SITE_FILE} --group default
+try pdo-sservice create_from_site ${SHORT_OPTS} --file ${F_SERVICE_SITE_FILE} --group default \
+             --replicas 1 --duration 60
 
 # -----------------------------------------------------------------
 # setup the contexts that will be used later for the tests, check this


### PR DESCRIPTION
Replace invocation of the script for building a local groups and services database with one that uses the public interfaces for the services and groups databases. Move away from "host specific" configuration to a configuration based on the more general site configuration file (i.e. site.toml).
    
By default, testing will still occur with locally hosted services. Importing a site configuration file from another service provider (which just involves copying the site configuration file to ${PDO_HOME}/etc/sites/${SERVICE_HOST}.toml) enables use of PDO services from any location.

This is a draft until the corresponding PR (https://github.com/hyperledger-labs/private-data-objects/pull/481) is committed to PDO. Before it is committed, the private-data-object submodule must be updated.