### PR TITLE
Enable starting guardian sservice at specified interface

### DIFF
--- a/docker/tools/start_guardian.sh
+++ b/docker/tools/start_guardian.sh
@@ -92,7 +92,8 @@ try ${PDO_HOME}/contracts/inference/scripts/ss_start.sh -c -o ${PDO_HOME}/logs -
     --loglevel ${F_LOGLEVEL} \
     --config guardian_service.toml \
     --config-dir ${PDO_HOME}/etc/contracts \
-    --identity guardian_sservice
+    --identity guardian_sservice \
+    --bind host ${F_INTERFACE}
 
 try ${PDO_HOME}/contracts/inference/scripts/gs_start.sh -c -o ${PDO_HOME}/logs -- \
     --loglevel ${F_LOGLEVEL} \


### PR DESCRIPTION
This PR makes it possible to start guardian sservice at the specified interface rather than default localhost

Signed-off-by: Prakash Narayana Moorthy <prakash.narayana.moorthy@intel.com>