### PR TITLE
Fix Context naming issues with inference contracts

### DIFF
--- a/inference-contract/docs/notebooks/templates/token-issuer.py
+++ b/inference-contract/docs/notebooks/templates/token-issuer.py
@@ -97,13 +97,13 @@ print("using context file {}".format(context_file))
 context_bindings = {
     'asset_type.identity' : token_owner,
     'vetting.identity' : token_owner,
-    'guardian.identity' : token_owner,
-    'token_issuer.identity' : token_owner,
-    'token_issuer.count' : count,
-    'token_issuer.description' : token_description,
-    'token_issuer.token_metadata.opaque' : token_metadata,
-    'token_object.identity' : token_owner,
-    'guardian.url' : 'http://' + service_host + ':7900'
+    'inf_guardian.identity' : token_owner,
+    'inf_token_issuer.identity' : token_owner,
+    'inf_token_issuer.count' : count,
+    'inf_token_issuer.description' : token_description,
+    'inf_token_issuer.token_metadata.opaque' : token_metadata,
+    'inf_token_object.identity' : token_owner,
+    'inf_guardian.url' : 'http://' + service_host + ':7900'
 }
 
 context = pc_jupyter.ml_jupyter.initialize_token_context(state, bindings, context_file, token_path, **context_bindings)
@@ -121,7 +121,7 @@ print('context initialized')
 # with tokens and other digital assets.
 
 # %%
-token_issuer_context = pc_jupyter.pbuilder.Context(state, token_path + '.token_issuer')
+token_issuer_context = pc_jupyter.pbuilder.Context(state, token_path + '.inf_token_issuer')
 token_issuer_save_file = token_issuer_context.get('save_file')
 if not token_issuer_save_file :
     token_issuer_save_file = pc_jupyter.pcommand.invoke_contract_cmd(
@@ -139,7 +139,7 @@ print('token issuer contract in {}'.format(token_issuer_save_file))
 # ### Mint the Tokens
 
 # %%
-token_object_context = pc_jupyter.pbuilder.Context(state, token_path + '.token_object')
+token_object_context = pc_jupyter.pbuilder.Context(state, token_path + '.inf_token_object')
 
 minted_token_save_files = pc_jupyter.pcommand.invoke_contract_cmd(
     pc_jupyter.ml_inference_token_object.cmd_mint_tokens, state, token_object_context)
@@ -196,7 +196,7 @@ for token_context in minted_token_contexts :
 
 # %%
 contract_identifier = '{}_{}'.format(token_class, instance_identifier)
-contexts = ['asset_type', 'vetting', 'guardian', 'token_issuer', 'token_object']
+contexts = ['asset_type', 'vetting', 'inf_guardian', 'inf_token_issuer', 'inf_token_object']
 contract_files = {
     'asset_type' : context.get('asset_type.save_file'),
     'vetting' : context.get('vetting.save_file'),

--- a/inference-contract/docs/notebooks/templates/token.py
+++ b/inference-contract/docs/notebooks/templates/token.py
@@ -37,7 +37,7 @@
 token_owner = 'user1'
 token_class = 'mytoken'
 token_name = 'token_1'
-token_path = 'token.${token_class}.token_object.${token_name}'
+token_path = 'token.${token_class}.inf_token_object.${token_name}'
 context_file = '${etc}/${token_class}_context.toml'
 service_host = 'localhost'
 instance_identifier = ''

--- a/inference-contract/pdo/inference/jupyter.py
+++ b/inference-contract/pdo/inference/jupyter.py
@@ -17,49 +17,21 @@ import os
 import sys
 
 from pdo.contracts.common import add_context_mapping, initialize_context
+import pdo.exchange.jupyter as ex_jupyter
 
 _logger = logging.getLogger(__name__)
 
 # -----------------------------------------------------------------
 # set up the context
 # -----------------------------------------------------------------
-asset_type_context = {
-    'module' : 'pdo.exchange.plugins.asset_type',
-    'identity' : None,
-    'source' : '${ContractFamily.Exchange.asset_type.source}',
-    'name' : 'asset_type',
-    'description' : 'asset type',
-    'link' : 'http://',
-    'eservice_group' : 'default',
-    'pservice_group' : 'default',
-    'sservice_group' : 'default',
-}
 
-vetting_context = {
-    'module' : 'pdo.exchange.plugins.vetting',
-    'identity' : None,
-    'source' : '${ContractFamily.Exchange.vetting.source}',
-    'asset_type_context' : '@{..asset_type}',
-    'eservice_group' : 'default',
-    'pservice_group' : 'default',
-    'sservice_group' : 'default',
-}
-
-issuer_context = {
-    'module' : 'pdo.exchange.plugins.issuer',
-    'identity' : None,
-    'source' : '${ContractFamily.Exchange.issuer.source}',
-    'asset_type_context' : '@{..asset_type}',
-    'vetting_context' : '@{..vetting}',
-    'eservice_group' : 'default',
-    'pservice_group' : 'default',
-    'sservice_group' : 'default',
-}
+# The asset_type_context, vetting_context, and issuer_context are defined in pdo.exchange.jupyter
+# and will get added to global context map automatically, since we import pdo.exchange.jupyter
 
 guardian_context = {
     'module' : 'pdo.inference.plugins.inference_guardian',
-    'identity' : '${..token_issuer.identity}',
-    'token_issuer_context' : '@{..token_issuer}',
+    'identity' : '${..inf_token_issuer.identity}',
+    'token_issuer_context' : '@{..inf_token_issuer}',
     'service_only' : True,
     'url' : 'http://localhost:7900',
 }
@@ -68,9 +40,9 @@ token_issuer_context = {
     'module' : 'pdo.exchange.plugins.token_issuer',
     'identity' : None,
     'source' : '${ContractFamily.Exchange.token_issuer.source}',
-    'token_object_context' : '@{..token_object}',
+    'token_object_context' : '@{..inf_token_object}',
     'vetting_context' : '@{..vetting}',
-    'guardian_context' : '@{..guardian}',
+    'guardian_context' : '@{..inf_guardian}',
     'description' : 'issuer for token',
     'token_metadata' : {
         'opaque' : '',
@@ -85,8 +57,8 @@ token_object_context = {
     'module' : 'pdo.inference.plugins.inference_token_object',
     'identity' : '${..token_issuer.identity}',
     'source' : '${ContractFamily.inference.token_object.source}',
-    'token_issuer_context' : '@{..token_issuer}',
-    'data_guardian_context' : '@{..guardian}',
+    'token_issuer_context' : '@{..inf_token_issuer}',
+    'data_guardian_context' : '@{..inf_guardian}',
     'eservice_group' : 'default',
     'pservice_group' : 'default',
     'sservice_group' : 'default',
@@ -110,26 +82,24 @@ order_context = {
 }
 
 _context_map_ = {
-    'asset_type' : asset_type_context,
-    'vetting' : vetting_context,
-    'issuer' : issuer_context,
-    'guardian' : guardian_context,
-    'token_issuer' : token_issuer_context,
-    'token_object' : token_object_context,
-    'order' : order_context,
+    'inf_guardian' : guardian_context,
+    'inf_token_issuer' : token_issuer_context,
+    'inf_token_object' : token_object_context,
+    'inf_order' : order_context,
 }
 
 for k, t in _context_map_.items() :
     add_context_mapping(k, t)
 
 def initialize_asset_context(state, bindings, context_file, prefix, **kwargs) :
+    # See pdo.exchange.jupyter for definitions of asset_type_context, vetting_context, and issuer_context
     contexts = ['asset_type', 'vetting', 'issuer']
     return initialize_context(state, bindings, context_file, prefix, contexts, **kwargs)
 
 def initialize_token_context(state, bindings, context_file, prefix, **kwargs) :
-    contexts = ['asset_type', 'vetting', 'guardian', 'token_issuer', 'token_object']
+    contexts = ['asset_type', 'vetting', 'inf_guardian', 'inf_token_issuer', 'inf_token_object']
     return initialize_context(state, bindings, context_file, prefix, contexts, **kwargs)
 
 def initialize_order_context(state, bindings, context_file, prefix, **kwargs) :
-    contexts = ['order']
+    contexts = ['inf_order']
     return initialize_context(state, bindings, context_file, prefix, contexts, **kwargs)


### PR DESCRIPTION
1. Reuse vetting, asset, and issuer context from exchange modules for the inference jupyter module, rather than redefining. 
2. Renamed the inference specific contexts to prevent overwriting of exchange related contexts
3. With these changes, a single instance of jupyter container can be used to interact with both inference and exchange contracts