### PR TITLE
Make the jupyter context functions more robust

### DIFF
--- a/exchange-contract/pdo/contracts/common.py
+++ b/exchange-contract/pdo/contracts/common.py
@@ -26,18 +26,17 @@ _logger = logging.getLogger(__name__)
 # -----------------------------------------------------------------
 # set up the context
 # -----------------------------------------------------------------
-_context_map_ = {
-}
+class ContextTemplate(object) :
+    """Capture information for a context template
 
-def add_context_mapping(k : str, template : dict) :
-    """Add a mapping from a keyword to a context template
-
-    Mappings provide a shortcut for referencing context templates
-    that can be used to initialize a full context; this procedure
-    adds a binding between a key word and a template.
+    A context template captures configuration information
+    generally associated with a specific contract class. For
+    the moment this is very simple.
     """
-    global _context_map_
-    _context_map_[k] = template
+
+    def __init__(self, key, template) :
+        self.key = key
+        self.template = copy.deepcopy(template)
 
 # -----------------------------------------------------------------
 # initialize_context
@@ -47,7 +46,7 @@ def initialize_context(
     bindings,
     context_file : str,
     prefix : str,
-    contexts : typing.List[str],
+    contexts : typing.List[ContextTemplate],
     **kwargs) -> pbuilder.Context :
 
     # attempt to load the context from the context file
@@ -59,7 +58,7 @@ def initialize_context(
     context =  pbuilder.Context(state, prefix)
     if not context.has_key('initialized') :
         for c in contexts :
-            context.set(c, copy.deepcopy(_context_map_[c]))
+            context.set(c.key, copy.deepcopy(c.template))
 
         context.set('initialized', True)
 

--- a/exchange-contract/pdo/contracts/jupyter.py
+++ b/exchange-contract/pdo/contracts/jupyter.py
@@ -256,8 +256,8 @@ for cf, cs in _contract_families_.items() :
         jupyter_name = 'pdo.{}.jupyter'.format(cf)
         jupyter_module = importlib.import_module(jupyter_name)
         globals()['{}_jupyter'.format(cs)] = jupyter_module
-    except :
-        pass
+    except Exception as e :
+        raise ImportError('Failed to import module for contract family {}; {}'.format(cf, e))
 
     # load the plugins module for the contract family, this
     # should provide a list of all the plugins in the family

--- a/exchange-contract/pdo/exchange/jupyter.py
+++ b/exchange-contract/pdo/exchange/jupyter.py
@@ -13,17 +13,15 @@
 # limitations under the License.
 
 import logging
-import os
-import sys
 
-from pdo.contracts.common import add_context_mapping, initialize_context
+import pdo.contracts.common as jp_common
 
 _logger = logging.getLogger(__name__)
 
 # -----------------------------------------------------------------
 # set up the context
 # -----------------------------------------------------------------
-_asset_type_context_ = {
+asset_type_context = jp_common.ContextTemplate('asset_type', {
     'module' : 'pdo.exchange.plugins.asset_type',
     'identity' : None,
     'source' : '${ContractFamily.Exchange.asset_type.source}',
@@ -33,9 +31,9 @@ _asset_type_context_ = {
     'eservice_group' : 'default',
     'pservice_group' : 'default',
     'sservice_group' : 'default',
-}
+})
 
-_vetting_context_ = {
+vetting_context = jp_common.ContextTemplate('vetting', {
     'module' : 'pdo.exchange.plugins.vetting',
     'identity' : None,
     'source' : '${ContractFamily.Exchange.vetting.source}',
@@ -43,9 +41,9 @@ _vetting_context_ = {
     'eservice_group' : 'default',
     'pservice_group' : 'default',
     'sservice_group' : 'default',
-}
+})
 
-_issuer_context_ = {
+issuer_context = jp_common.ContextTemplate('issuer', {
     'module' : 'pdo.exchange.plugins.issuer',
     'identity' : None,
     'source' : '${ContractFamily.Exchange.issuer.source}',
@@ -54,9 +52,9 @@ _issuer_context_ = {
     'eservice_group' : 'default',
     'pservice_group' : 'default',
     'sservice_group' : 'default',
-}
+})
 
-_guardian_context_ = {
+guardian_context = jp_common.ContextTemplate('guardian', {
     'module' : 'pdo.exchange.plugins.guardian',
     'identity' : '${..token_issuer.identity}',
     'source' : '${ContractFamily.Exchange.data_guardian.source}',
@@ -64,9 +62,9 @@ _guardian_context_ = {
     'eservice_group' : 'default',
     'pservice_group' : 'default',
     'sservice_group' : 'default',
-}
+})
 
-_token_issuer_context_ = {
+token_issuer_context = jp_common.ContextTemplate('token_issuer', {
     'module' : 'pdo.exchange.plugins.token_issuer',
     'identity' : None,
     'source' : '${ContractFamily.Exchange.token_issuer.source}',
@@ -81,9 +79,9 @@ _token_issuer_context_ = {
     'eservice_group' : 'default',
     'pservice_group' : 'default',
     'sservice_group' : 'default',
-}
+})
 
-_token_object_context_ = {
+token_object_context = jp_common.ContextTemplate('token_object', {
     'module' : 'pdo.exchange.plugins.token_object',
     'identity' : '${..token_issuer.identity}',
     'source' : '${ContractFamily.Exchange.token_object.source}',
@@ -92,9 +90,9 @@ _token_object_context_ = {
     'eservice_group' : 'default',
     'pservice_group' : 'default',
     'sservice_group' : 'default',
-}
+})
 
-_order_context_ = {
+order_context = jp_common.ContextTemplate('exchange', {
     'module' : 'pdo.exchange.plugins.exchange',
     'identity' : None,
     'source' : '${ContractFamily.Exchange.exchange.source}',
@@ -109,21 +107,7 @@ _order_context_ = {
     'eservice_group' : 'default',
     'pservice_group' : 'default',
     'sservice_group' : 'default',
-}
-
-# add each of these to the global mapping
-_context_map_ = {
-    'asset_type' : _asset_type_context_,
-    'vetting' : _vetting_context_,
-    'issuer' : _issuer_context_,
-    'guardian' : _guardian_context_,
-    'token_issuer' : _token_issuer_context_,
-    'token_object' : _token_object_context_,
-    'order' : _order_context_,
-}
-
-for k, t in _context_map_.items() :
-    add_context_mapping(k, t)
+})
 
 def initialize_asset_context(state, bindings, context_file : str, prefix : str, **kwargs) :
     """Initialize a context for issuing assets
@@ -140,8 +124,8 @@ def initialize_asset_context(state, bindings, context_file : str, prefix : str, 
     @rtype: pdo.client.builder.context.Context
     @return: the initialized context
     """
-    contexts = ['asset_type', 'vetting', 'issuer']
-    return initialize_context(state, bindings, context_file, prefix, contexts, **kwargs)
+    contexts = [asset_type_context, vetting_context, issuer_context]
+    return jp_common.initialize_context(state, bindings, context_file, prefix, contexts, **kwargs)
 
 def initialize_token_context(state, bindings, context_file : str, prefix : str, **kwargs) :
     """Initialize a context for minting tokens
@@ -159,8 +143,8 @@ def initialize_token_context(state, bindings, context_file : str, prefix : str, 
     @rtype: pdo.client.builder.context.Context
     @return: the initialized context
     """
-    contexts = ['asset_type', 'vetting', 'guardian', 'token_issuer', 'token_object']
-    return initialize_context(state, bindings, context_file, prefix, contexts, **kwargs)
+    contexts = [asset_type_context, vetting_context, guardian_context, token_issuer_context, token_object_context]
+    return jp_common.initialize_context(state, bindings, context_file, prefix, contexts, **kwargs)
 
 def initialize_order_context(state, bindings, context_file, prefix, **kwargs) :
     """Initialize a context for creating an order to exchange assets
@@ -177,5 +161,5 @@ def initialize_order_context(state, bindings, context_file, prefix, **kwargs) :
     @rtype: pdo.client.builder.context.Context
     @return: the initialized context
     """
-    contexts = ['order']
-    return initialize_context(state, bindings, context_file, prefix, contexts, **kwargs)
+    contexts = [order_context]
+    return jp_common.initialize_context(state, bindings, context_file, prefix, contexts, **kwargs)


### PR DESCRIPTION
In order to support multiple namespaces for the contexts used in jupyter notebooks, make the context names and data more explicit. Fixes a problem with the exchange token issuer caused by a conflict in contexts.