### PR TITLE
Switch notebooks to use service groups instead of a fixed host

### DIFF
--- a/docs/notebooks/documents/getting_started.py
+++ b/docs/notebooks/documents/getting_started.py
@@ -15,9 +15,9 @@
 # %% [markdown]
 # # Managing the PDO Environment
 #
-# This notebook provides an aggregate interface for preparing to work with PDO contracts through the
-# necessary steps to set up a functional configuration. It assumes that the reader is familiar with
-# [basic operation of Jupyter notebooks](https://jupytext.readthedocs.io/en/latest/).
+# This notebook provides an aggregate interface for preparing to work with PDO contracts and
+# describes the necessary steps to set up a functional configuration. It assumes that the reader is
+# familiar with [basic operation of Jupyter notebooks](https://jupytext.readthedocs.io/en/latest/).
 #
 # This notebook helps to setup and verify the PDO environment in which the notebooks operate. If you
 # have started the Jupyter Lab server through the PDO contracts docker test interface, a basic

--- a/exchange-contract/docs/notebooks/factories/exchange_create.py
+++ b/exchange-contract/docs/notebooks/factories/exchange_create.py
@@ -44,7 +44,7 @@ offer_context_file = input('Path to the contract context file for the offer issu
 offer_count = input('How many assets do you want to offer [1]') or 1
 request_context_file = input('Path to the contract context file for the requested issuer')
 request_count = input('How many assets do you want to receive [1]') or 1
-service_host = input('Service host [localhost]: ') or "localhost"
+service_group = input('Service group [default]: ') or "default"
 
 # %% [markdown]
 # ## Create a New Exchange Notebook
@@ -58,7 +58,7 @@ parameters = {
     'offer_count' : int(offer_count),
     'request_context_file' : request_context_file,
     'request_count' : int(request_count),
-    'service_host' : service_host,
+    'service_group' : service_group,
 }
 
 instance_file = pc_jupyter.instantiate_notebook_from_template('exchange', 'exchange_create', parameters)

--- a/exchange-contract/docs/notebooks/factories/issuer.py
+++ b/exchange-contract/docs/notebooks/factories/issuer.py
@@ -39,7 +39,7 @@ identity = input('Identity of the issuer: ')
 asset_name = input('Name of the asset:')
 asset_description = input('Description of the asset: ')
 asset_link = input('Link to more information about the asset [http://]: ') or 'http://'
-service_host = input('Service host [localhost]: ') or 'localhost'
+service_group = input('Service group [default]: ') or 'default'
 
 # %% [markdown]
 # ## Create the Issuer Notebook
@@ -52,7 +52,7 @@ parameters = {
     'asset_name' : asset_name,
     'asset_description' : asset_description,
     'asset_link' : asset_link,
-    'service_host' : service_host,
+    'service_group' : service_group,
 }
 
 instance_file = pc_jupyter.instantiate_notebook_from_template(asset_name, 'issuer', parameters)

--- a/exchange-contract/docs/notebooks/factories/token-issuer.py
+++ b/exchange-contract/docs/notebooks/factories/token-issuer.py
@@ -39,7 +39,7 @@ identity = input('Identity of the token issuer: ')
 token_class = input('Name of the class of tokens to issue: ')
 token_description = input('Description of the token [my token]') or 'my token'
 count = input('Number of tokens to mint [5] ') or 5
-service_host = input('Service host [localhost]: ') or "localhost"
+service_group = input('Service group [default]: ') or "default"
 
 # %% [markdown]
 # ## Create the Token Issuer Notebook
@@ -53,7 +53,7 @@ instance_parameters = {
     'token_class' : token_class,
     'token_description' : token_description,
     'count' : int(count),
-    'service_host' : service_host,
+    'service_group' : service_group,
 }
 
 instance_file = pc_jupyter.instantiate_notebook_from_template(token_class, 'token-issuer', instance_parameters)

--- a/exchange-contract/docs/notebooks/templates/exchange_create.py
+++ b/exchange-contract/docs/notebooks/templates/exchange_create.py
@@ -44,7 +44,7 @@ request_context_file = '${etc}/context/request_issuer.toml'
 request_count = 1
 exchange_context_file = '${etc}/context/exchange_${instance}.toml'
 instance_identifier = ''
-service_host = 'localhost'
+service_group = 'default'
 
 # %% [markdown]
 # <hr style="border:2px solid gray">
@@ -63,7 +63,9 @@ pc_jupyter.load_ipython_extension(get_ipython())
 #
 # Initialize the PDO environment. This assumes that a functional PDO configuration is in place and
 # that the PDO virtual environment has been activated. In particular, ensure that the groups file
-# and eservice database have been configured correctly.
+# and eservice database have been configured correctly.  If you do not have a service groups
+# configuration, you can set it up with the
+# [service groups manager](/documents/service_groups_manager.ipynb) page.
 #
 # In the next box we will set up the PDO client configuration. This will load any client
 # configuration files, service group files, and service database files. Common bindings provides a
@@ -73,8 +75,6 @@ pc_jupyter.load_ipython_extension(get_ipython())
 
 # %%
 common_bindings = {
-    'host' : service_host,
-    'service_host' : service_host,
     'instance' : instance_identifier,
 }
 
@@ -89,7 +89,10 @@ print('environment initialized')
 # %% [markdown]
 # ### Import the Issuer Contracts
 #
-# The exchange notebook assumes that issuer contracts have been fully imported and the context files are available. If you received the issuer contracts as contract export files, import them into your local configuration. Adjust the name of the file to reflect where the contract export files are located.
+# The exchange notebook assumes that issuer contracts have been fully imported and the context files
+# are available. If you received the issuer contracts as contract export files, import them into
+# your local configuration. Adjust the name of the file to reflect where the contract export files
+# are located.
 
 # %%
 # %%skip True
@@ -104,13 +107,17 @@ pc_jupyter.import_context_file(state, bindings, request_context_file, import_fil
 # %% [markdown]
 # ### Create the Exchange Contract Context
 #
-# Create a new exchange contract context. The contract context defines the configuration for a collection of contract objects that interact with one another. By default, the context file used in this notebook is specific to the exchange contract object that will be created. If you prefer to use a common context file, edit the context_file variable below.
+# Create a new exchange contract context. The contract context defines the configuration for a
+# collection of contract objects that interact with one another. By default, the context file used
+# in this notebook is specific to the exchange contract object that will be created. If you prefer
+# to use a common context file, edit the context_file variable below.
 
 # %% [markdown]
 # #### Import the Asset Issuer Contexts
 #
-# The context files for the assets used for the offer and request must be available. The file names for these context files should have been set above. The context for each of the issuers will be loaded with the exchange instance identifier prefix.
-
+# The context files for the assets used for the offer and request must be available. The file names
+# for these context files should have been set above. The context for each of the issuers will be
+# loaded with the exchange instance identifier prefix.
 # %%
 pc_jupyter.pcontext.Context.LoadContextFile(
     state, bindings, offer_context_file, prefix='{}.offer'.format(instance_identifier))
@@ -121,20 +128,15 @@ pc_jupyter.pcontext.Context.LoadContextFile(
 # %% [markdown]
 # #### Create the Exchange Context
 #
-# Create the context for the exchange contract. In addition, we need to ensure that the identity used to interact with the issuer contracts is the same as the identity used for the exchange contract. For the most part, all settings should have been set above.
-
+# Create the context for the exchange contract. In addition, we need to ensure that the identity
+# used to interact with the issuer contracts is the same as the identity used for the exchange
+# contract. For the most part, all settings should have been set above.
 # %%
 context_bindings = {
     'identity' : identity,
-    'order.identity' : identity,
+    'service_group' : service_group,
     'order.offer.count' : offer_count,
     'order.request.count' : request_count,
-    'request.asset_type.identity' : identity,
-    'request.vetting.identity' : identity,
-    'request.issuer.identity' : identity,
-    'offer.asset_type.identity' : identity,
-    'offer.vetting.identity' : identity,
-    'offer.issuer.identity' : identity
 }
 
 context = pc_jupyter.ex_jupyter.initialize_order_context(

--- a/exchange-contract/docs/notebooks/templates/exchange_import.py
+++ b/exchange-contract/docs/notebooks/templates/exchange_import.py
@@ -57,7 +57,9 @@ pc_jupyter.load_ipython_extension(get_ipython())
 #
 # Initialize the PDO environment. This assumes that a functional PDO configuration is in place and
 # that the PDO virtual environment has been activated. In particular, ensure that the groups file
-# and eservice database have been configured correctly.
+# and eservice database have been configured correctly.  If you do not have a service groups
+# configuration, you can set it up with the
+# [service groups manager](/documents/service_groups_manager.ipynb) page.
 #
 # For the most part, no modifications should be required below.
 

--- a/exchange-contract/docs/notebooks/templates/issuer.py
+++ b/exchange-contract/docs/notebooks/templates/issuer.py
@@ -44,10 +44,8 @@ identity = 'user'
 asset_name = 'asset'
 asset_description = 'this is an asset'
 asset_link = 'http://'
-context_file = '${etc}/context/${asset_name}_${instance}.toml'
 instance_identifier = ''
-service_host = 'localhost'
-
+service_group = 'default'
 # %% [markdown]
 # <hr style="border:2px solid gray">
 #
@@ -65,13 +63,13 @@ pc_jupyter.load_ipython_extension(get_ipython())
 #
 # Initialize the PDO environment. This assumes that a functional PDO configuration is in place and
 # that the PDO virtual environment has been activated. In particular, ensure that the groups file
-# and eservice database have been configured correctly.
+# and eservice database have been configured correctly.  If you do not have a service groups
+# configuration, you can set it up with the
+# [service groups manager](/documents/service_groups_manager.ipynb) page.
 #
 # For the most part, no modifications should be required below.
 # %%
 common_bindings = {
-    'host' : service_host,
-    'service_host' : service_host,
     'asset_name' : asset_name,
     'instance' : instance_identifier,
 }
@@ -91,16 +89,15 @@ print('environment initialized')
 
 # %%
 asset_path = 'asset.' + asset_name
-context_file = bindings.expand(context_file)
+context_file = bindings.expand('${etc}/context/${asset_name}_${instance}.toml')
 print("using context file {}".format(context_file))
 
 context_bindings = {
-    'asset_type.identity' : identity,
+    'identity' : identity,
+    'service_group' : service_group,
     'asset_type.name' : asset_name,
     'asset_type.description' : asset_description,
     'asset_type.link' : asset_link,
-    'vetting.identity' : identity,
-    'issuer.identity' : identity,
 }
 context = pc_jupyter.ex_jupyter.initialize_asset_context(
     state, bindings, context_file, asset_path, **context_bindings)

--- a/exchange-contract/docs/notebooks/templates/token-issuer.py
+++ b/exchange-contract/docs/notebooks/templates/token-issuer.py
@@ -36,7 +36,7 @@ token_class = 'mytoken'
 token_description = 'this is my token'
 token_metadata = 'created by {}'.format(token_owner)
 count = 5
-service_host = 'localhost'
+service_group = 'default'
 instance_identifier = ''
 
 # %% [markdown]
@@ -56,13 +56,13 @@ pc_jupyter.load_ipython_extension(get_ipython())
 #
 # Initialize the PDO environment. This assumes that a functional PDO configuration is in place and
 # that the PDO virtual environment has been activated. In particular, ensure that the groups file
-# and eservice database have been configured correctly.
+# and eservice database have been configured correctly. If you do not have a service groups
+# configuration, you can set it up with the
+# [service groups manager](/documents/service_groups_manager.ipynb) page.
 #
 # For the most part, no modifications should be required below.
 # %%
 common_bindings = {
-    'host' : service_host,
-    'service_host' : service_host,
     'token_owner' : token_owner,
     'token_class' : token_class,
 }
@@ -83,14 +83,11 @@ context_file = bindings.expand('${etc}/${token_class}_context.toml')
 print("using context file {}".format(context_file))
 
 context_bindings = {
-    'asset_type.identity' : token_owner,
-    'vetting.identity' : token_owner,
-    'guardian.identity' : token_owner,
-    'token_issuer.identity' : token_owner,
+    'identity' : token_owner,
+    'service_group' : service_group,
     'token_issuer.count' : count,
     'token_issuer.description' : token_description,
     'token_issuer.token_metadata.opaque' : token_metadata,
-    'token_object.identity' : token_owner,
 }
 
 context = pc_jupyter.ex_jupyter.initialize_token_context(state, bindings, context_file, token_path, **context_bindings)
@@ -144,7 +141,6 @@ parameters = {
     'token_owner' : token_owner,
     'token_class' : token_class,
     'context_file' : context_file,
-    'service_host' : service_host,
 }
 
 for token_context in minted_token_contexts :

--- a/exchange-contract/docs/notebooks/templates/token.py
+++ b/exchange-contract/docs/notebooks/templates/token.py
@@ -38,7 +38,6 @@ token_class = 'mytoken'
 token_name = 'token_1'
 token_path = 'token.${token_class}.token_object.${token_name}'
 context_file = '${etc}/${token_class}_context.toml'
-service_host = 'localhost'
 instance_identifier = ''
 
 # %% [markdown]
@@ -57,14 +56,11 @@ pc_jupyter.load_ipython_extension(get_ipython())
 # ### Initialize the PDO Environment
 #
 # Initialize the PDO environment. This assumes that a functional PDO configuration is in place and
-# that the PDO virtual environment has been activated. In particular, ensure that the groups file
-# and eservice database have been configured correctly.
+# that the PDO virtual environment has been activated.
 #
 # For the most part, no modifications should be required below.
 # %%
 common_bindings = {
-    'host' : service_host,
-    'service_host' : service_host,
     'token_owner' : token_owner,
     'token_class' : token_class,
     'token_name' : token_name,
@@ -76,7 +72,11 @@ print('environment initialized')
 # %% [markdown]
 # ### Initialize the Contract Context
 #
-# The contract context defines the configuration for a collection of contract objects that interact with one another. By default, the context file used in this notebook is specific to the toke class used to mint the token. We need the class to ensure that all of the information necessary for the token itself is availablen. If you prefer to use a common context file, edit the context_file variable below.
+# The contract context defines the configuration for a collection of contract objects that interact
+# with one another. By default, the context file used in this notebook is specific to the toke class
+# used to mint the token. We need the class to ensure that all of the information necessary for the
+# token itself is availablen. If you prefer to use a common context file, edit the context_file
+# variable below.
 #
 # For the most part, no other modifications should be required.
 
@@ -85,13 +85,18 @@ token_class_path = 'token.' + token_class
 context_file = bindings.expand(context_file)
 print("using context file {}".format(context_file))
 
-context = pc_jupyter.ex_jupyter.initialize_token_context(state, bindings, context_file, token_class_path)
+context_bindings = {
+    'identity' : token_owner,
+}
+
+context = pc_jupyter.ex_jupyter.initialize_token_context(
+    state, bindings, context_file, token_class_path, **context_bindings)
 print('context initialized')
 
 # %% [markdown]
 # <hr style="border:2px solid gray">
 #
-# ## Operate on the Contract
+# ## Operate on the Token Contract
 
 # %%
 token_context = pc_jupyter.pbuilder.Context(state, token_path)
@@ -100,11 +105,19 @@ token_context = pc_jupyter.pbuilder.Context(state, token_path)
 # ### Invoke Echo Operation
 
 # %%
-# %%skip True
-message = 'hello from token {}'.format(token_path)
-echo_result = pc_jupyter.pcommand.invoke_contract_cmd(
-    pc_jupyter.ex_token_object.cmd_echo, state, token_context, message=message)
+def token_echo(message) :
+    return pc_jupyter.pcommand.invoke_contract_cmd(
+        pc_jupyter.ex_token_object.cmd_echo, state, token_context, message=message)
 
+# token_echo('hello from token {}'.format(token_path))
+# %% [markdown]
+# ### Transfer Ownership
+# %%
+def token_transfer(new_owner) :
+    return pc_jupyter.pcommand.invoke_contract_cmd(
+        pc_jupyter.ex_issuer.cmd_transfer_assets, state, token_context, new_owner=new_owner)
+
+# token_transfer('user2')
 # %% [markdown]
 # <hr style="border:2px solid gray">
 #

--- a/exchange-contract/docs/notebooks/templates/wallet.py
+++ b/exchange-contract/docs/notebooks/templates/wallet.py
@@ -16,7 +16,8 @@
 # *WORK IN PROGRESS*
 # # Wallet Notebook
 #
-# This notebook is used to manage the assets issued to an indivdual by an issuer contract. The notebook assumes that the asset type, vetting, and issuer contract objects have been created.
+# This notebook is used to manage the assets issued to an indivdual by an issuer contract. The
+# notebook assumes that the asset type, vetting, and issuer contract objects have been created.
 
 # %% [markdown] editable=true slideshow={"slide_type": ""}
 # <hr style="border:2px solid gray">
@@ -28,7 +29,8 @@
 # * asset_name : the name of the asset type to be created
 # * context_file : the name of the context file where token information is located
 #
-# When this notebook is instantiated, it will generally provide default values for `identity`, `asset_name`, `context_file` and `notebook_directory`.
+# When this notebook is instantiated, it will generally provide default values for `identity`,
+# `asset_name`, `context_file` and `notebook_directory`.
 #
 # Note that the notebook assumes that there is a key file for the identity of the form
 #
@@ -57,12 +59,13 @@ pc_jupyter.load_ipython_extension(get_ipython())
 # %% [markdown]
 # ### Initialize the PDO Environment
 #
-# Initialize the PDO environment. This assumes that a functional PDO configuration is in place and that the PDO virtual environment has been activated. In particular, ensure that the groups file and eservice database have been configured correctly. This can be done most easily by running the following in a shell:
-
+# Initialize the PDO environment. This assumes that a functional PDO configuration is in place and
+# that the PDO virtual environment has been activated. In particular, ensure that the groups file
+# and eservice database have been configured correctly.  If you do not have a service groups
+# configuration, you can set it up with the
+# [service groups manager](/documents/service_groups_manager.ipynb) page
 # %%
 common_bindings = {
-    'asset_name' : asset_name,
-    'notebook' : notebook_directory,
 }
 
 (state, bindings) = pc_jupyter.initialize_environment(identity, **common_bindings)
@@ -83,7 +86,10 @@ pc_jupyter.import_context(state, bindings, context_file, import_file)
 # %% [markdown]
 # ### Import the Context
 #
-# The contract context defines the configuration for a collection of contract objects that interact with one another. By default, the context file used in this notebook is specific to the asset class. We need the class to ensure that all of the information necessary for the asset itself is availaben. If you prefer to use a common context file, edit the context_file variable below.
+# The contract context defines the configuration for a collection of contract objects that interact
+# with one another. By default, the context file used in this notebook is specific to the asset
+# class. We need the class to ensure that all of the information necessary for the asset itself is
+# available. If you prefer to use a common context file, edit the context_file variable below.
 #
 # For the most part, no other modifications should be required.
 

--- a/exchange-contract/pdo/contracts/common.py
+++ b/exchange-contract/pdo/contracts/common.py
@@ -24,6 +24,19 @@ _logger = logging.getLogger(__name__)
 """
 
 # -----------------------------------------------------------------
+# the base context provides information that appears to be common
+# across all contexts; contexts can reference the values in the
+# base context to simplify consistent configuration
+# -----------------------------------------------------------------
+_base_context_ = {
+    'identity' : None,
+    'service_group' : 'default',          # the assumption here is that [eps]service groups all have the same name
+    'eservice_group' : '${.service_group}',
+    'pservice_group' : '${.service_group}',
+    'sservice_group' : '${.service_group}',
+}
+
+# -----------------------------------------------------------------
 # set up the context
 # -----------------------------------------------------------------
 class ContextTemplate(object) :
@@ -57,6 +70,10 @@ def initialize_context(
 
     context =  pbuilder.Context(state, prefix)
     if not context.has_key('initialized') :
+        # initialize the base context with common keys
+        for k, v in _base_context_.items() :
+            context.set(k, copy.deepcopy(v))
+
         for c in contexts :
             context.set(c.key, copy.deepcopy(c.template))
 

--- a/exchange-contract/pdo/contracts/jupyter.py
+++ b/exchange-contract/pdo/contracts/jupyter.py
@@ -235,7 +235,7 @@ def export_contract_collection(
 # -----------------------------------------------------------------
 def create_download_link(filename : str, label : str = 'Download File') :
     """Create HTML display that will download a file"""
-    content = '<a href={} download>{}</a>'.format(filename, label)
+    content = '<a href="{}" download>{}</a>'.format(filename, label)
     return ip_display.HTML(content)
 
 # -----------------------------------------------------------------

--- a/exchange-contract/pdo/exchange/jupyter.py
+++ b/exchange-contract/pdo/exchange/jupyter.py
@@ -23,35 +23,35 @@ _logger = logging.getLogger(__name__)
 # -----------------------------------------------------------------
 asset_type_context = jp_common.ContextTemplate('asset_type', {
     'module' : 'pdo.exchange.plugins.asset_type',
-    'identity' : None,
+    'identity' : '${..identity}',
     'source' : '${ContractFamily.Exchange.asset_type.source}',
     'name' : 'asset_type',
     'description' : 'asset type',
     'link' : 'http://',
-    'eservice_group' : 'default',
-    'pservice_group' : 'default',
-    'sservice_group' : 'default',
+    'eservice_group' : '${..eservice_group}',
+    'pservice_group' : '${..pservice_group}',
+    'sservice_group' : '${..sservice_group}',
 })
 
 vetting_context = jp_common.ContextTemplate('vetting', {
     'module' : 'pdo.exchange.plugins.vetting',
-    'identity' : None,
+    'identity' : '${..identity}',
     'source' : '${ContractFamily.Exchange.vetting.source}',
     'asset_type_context' : '@{..asset_type}',
-    'eservice_group' : 'default',
-    'pservice_group' : 'default',
-    'sservice_group' : 'default',
+    'eservice_group' : '${..eservice_group}',
+    'pservice_group' : '${..pservice_group}',
+    'sservice_group' : '${..sservice_group}',
 })
 
 issuer_context = jp_common.ContextTemplate('issuer', {
     'module' : 'pdo.exchange.plugins.issuer',
-    'identity' : None,
+    'identity' : '${..identity}',
     'source' : '${ContractFamily.Exchange.issuer.source}',
     'asset_type_context' : '@{..asset_type}',
     'vetting_context' : '@{..vetting}',
-    'eservice_group' : 'default',
-    'pservice_group' : 'default',
-    'sservice_group' : 'default',
+    'eservice_group' : '${..eservice_group}',
+    'pservice_group' : '${..pservice_group}',
+    'sservice_group' : '${..sservice_group}',
 })
 
 guardian_context = jp_common.ContextTemplate('guardian', {
@@ -59,14 +59,14 @@ guardian_context = jp_common.ContextTemplate('guardian', {
     'identity' : '${..token_issuer.identity}',
     'source' : '${ContractFamily.Exchange.data_guardian.source}',
     'token_issuer_context' : '@{..token_issuer}',
-    'eservice_group' : 'default',
-    'pservice_group' : 'default',
-    'sservice_group' : 'default',
+    'eservice_group' : '${..eservice_group}',
+    'pservice_group' : '${..pservice_group}',
+    'sservice_group' : '${..sservice_group}',
 })
 
 token_issuer_context = jp_common.ContextTemplate('token_issuer', {
     'module' : 'pdo.exchange.plugins.token_issuer',
-    'identity' : None,
+    'identity' : '${..identity}',
     'source' : '${ContractFamily.Exchange.token_issuer.source}',
     'token_object_context' : '@{..token_object}',
     'vetting_context' : '@{..vetting}',
@@ -76,9 +76,9 @@ token_issuer_context = jp_common.ContextTemplate('token_issuer', {
         'opaque' : '',
     },
     'count' : 10,
-    'eservice_group' : 'default',
-    'pservice_group' : 'default',
-    'sservice_group' : 'default',
+    'eservice_group' : '${..eservice_group}',
+    'pservice_group' : '${..pservice_group}',
+    'sservice_group' : '${..sservice_group}',
 })
 
 token_object_context = jp_common.ContextTemplate('token_object', {
@@ -87,14 +87,14 @@ token_object_context = jp_common.ContextTemplate('token_object', {
     'source' : '${ContractFamily.Exchange.token_object.source}',
     'token_issuer_context' : '@{..token_issuer}',
     'data_guardian_context' : '@{..guardian}',
-    'eservice_group' : 'default',
-    'pservice_group' : 'default',
-    'sservice_group' : 'default',
+    'eservice_group' : '${..eservice_group}',
+    'pservice_group' : '${..pservice_group}',
+    'sservice_group' : '${..sservice_group}',
 })
 
 order_context = jp_common.ContextTemplate('exchange', {
     'module' : 'pdo.exchange.plugins.exchange',
-    'identity' : None,
+    'identity' : '${..identity}',
     'source' : '${ContractFamily.Exchange.exchange.source}',
     'offer' : {
         'issuer_context' : '@{...offer.issuer}',
@@ -104,9 +104,9 @@ order_context = jp_common.ContextTemplate('exchange', {
         'issuer_context' : '@{...request.issuer}',
         'count' : 1,
     },
-    'eservice_group' : 'default',
-    'pservice_group' : 'default',
-    'sservice_group' : 'default',
+    'eservice_group' : '${..eservice_group}',
+    'pservice_group' : '${..pservice_group}',
+    'sservice_group' : '${..sservice_group}',
 })
 
 def initialize_asset_context(state, bindings, context_file : str, prefix : str, **kwargs) :

--- a/inference-contract/docs/notebooks/factories/token-issuer.py
+++ b/inference-contract/docs/notebooks/factories/token-issuer.py
@@ -49,8 +49,8 @@ pc_jupyter.load_ipython_extension(get_ipython())
 # %% tags=["parameters"]
 identity = input('Identity of the token issuer: ')
 token_class = input('Name of the class of tokens to issue: ')
-service_host = input('Service host [localhost]: ') or 'localhost'
-
+service_group = input('Service group [default]: ') or "default"
+guardian_host = input('Guardian host [localhost]: ') or 'localhost'
 
 # %% [markdown]
 # ## Create the Token Issuer Notebook
@@ -63,7 +63,8 @@ service_host = input('Service host [localhost]: ') or 'localhost'
 instance_parameters = {
     'token_owner' : identity,
     'token_class' : token_class,
-    'service_host' : service_host,
+    'service_group' : service_group,
+    'guardian_host' : guardian_host
 }
 
 instance_file = pc_jupyter.instantiate_notebook_from_template(token_class, 'token-issuer', instance_parameters)

--- a/inference-contract/docs/notebooks/templates/token.py
+++ b/inference-contract/docs/notebooks/templates/token.py
@@ -39,7 +39,6 @@ token_class = 'mytoken'
 token_name = 'token_1'
 token_path = 'token.${token_class}.token_object.${token_name}'
 context_file = '${etc}/${token_class}_context.toml'
-service_host = 'localhost'
 instance_identifier = ''
 
 # %%
@@ -54,18 +53,12 @@ pc_jupyter.load_ipython_extension(get_ipython())
 # ### Initialize the PDO Environment
 #
 # Initialize the PDO environment. This assumes that a functional PDO configuration
-# is in place and that the PDO virtual environment has been activated. In particular,
-# ensure that the groups file and eservice database have been configured correctly.
-This can be done most easily by running the following in a shell:
-#
-# `$PDO_HOME/bin/pdo-create-service-groups.psh --service_host <service_host>`
+# is in place and that the PDO virtual environment has been activated.
 #
 # For the most part, no modifications should be required below.
 
 # %%
 common_bindings = {
-    'host' : service_host,
-    'service_host' : service_host,
     'token_owner' : token_owner,
     'token_class' : token_class,
     'token_name' : token_name,

--- a/inference-contract/pdo/inference/jupyter.py
+++ b/inference-contract/pdo/inference/jupyter.py
@@ -36,9 +36,9 @@ token_object_context = jp_common.ContextTemplate('token_object', {
     'source' : '${ContractFamily.inference.token_object.source}',
     'token_issuer_context' : '@{..token_issuer}',
     'data_guardian_context' : '@{..guardian}',
-    'eservice_group' : 'default',
-    'pservice_group' : 'default',
-    'sservice_group' : 'default',
+    'eservice_group' : '${..eservice_group}',
+    'pservice_group' : '${..pservice_group}',
+    'sservice_group' : '${..sservice_group}',
 })
 
 def initialize_token_context(state, bindings, context_file, prefix, **kwargs) :


### PR DESCRIPTION
Update the notebooks to take advantage of the transition to service groups. This should enable significantly more flexibility in selecting services from multiple sites.
    
Changed some of the way the "root" of a context is handled in order to keep group specification easier. If all of the services groups (eservice, pservice, and sservice) have the same name then a single service group setting is sufficient to pick all. Otherwise, each group can be overridden in the custom bindings.
    
Fixed line length in several of the notebooks.
