### PR TITLE
Add dependabot to track deps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+version: 2
+
+updates:
+  - package-ecosystem: "gitsubmodule"
+    directory: "/"
+    allow:
+      - dependency-type: all
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
This PR allows dependabot to take the burden and bump the gitsubmodule of PDO automatically. 

An example can be found in my fork https://github.com/mbrandenburger/pdo-contracts/pulls
