### PR TITLE
Couple fixes that will make the multiuser tests easier to build

### DIFF
--- a/docker/Makefile
+++ b/docker/Makefile
@@ -211,6 +211,14 @@ test_jupyter : clean_config clean_repository clean_models build_contracts
 	PDO_VERSION=$(PDO_VERSION) CONTRACTS_VERSION=$(CONTRACTS_VERSION) \
 		$(DOCKER_COMPOSE_COMMAND) $(JUPYTER_COMPOSE_ARGS) down
 
+JUPYTER_MULTIUSER_COMPOSE_ARGS += -f test_multiuser_jupyter.yaml
+
+test_multiuser_jupyter : clean_config clean_repository clean_models build_contracts
+	- PDO_VERSION=$(PDO_VERSION) CONTRACTS_VERSION=$(CONTRACTS_VERSION) \
+		docker-compose $(JUPYTER_MULTIUSER_COMPOSE_ARGS) up --abort-on-container-exit
+	PDO_VERSION=$(PDO_VERSION) CONTRACTS_VERSION=$(CONTRACTS_VERSION) \
+		docker-compose $(JUPYTER_MULTIUSER_COMPOSE_ARGS) down
+
 # -----------------------------------------------------------------
 # Cleaning is a bit interesting because the containers don't go away
 # unless they are told to very nicely. Until they go away they hold onto

--- a/docker/test_multiuser_jupyter.yaml
+++ b/docker/test_multiuser_jupyter.yaml
@@ -1,0 +1,96 @@
+# Copyright 2024 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------------
+version: "3.4"
+
+# This file creates a complete environment for testing the contracts
+# through the jupyter notebook interface.
+
+# Note that we do not need to specify PDO_HOSTNAME or PDO_LEDGER_URL
+# (or the corresponding --inteface or --ledger switches) for the test
+# scripts because they are hard coded in run_*_tests.sh for each of the
+# containers.
+
+services:
+  ccf_container:
+    image: ${PDO_REPOSITORY:-}pdo_ccf:${PDO_VERSION:-latest}
+    container_name: ccf_container
+    network_mode: "host"
+    volumes:
+      - ./xfer/:/project/pdo/xfer/
+    entrypoint: /project/pdo/tools/start_ccf.sh -m build -i localhost --start
+
+  services_container:
+    image: ${PDO_REPOSITORY:-}pdo_services:${PDO_VERSION:-latest}
+    container_name: services_container
+    depends_on: [ ccf_container ]
+    network_mode: "host"
+    volumes:
+      - ./xfer/:/project/pdo/xfer/
+    entrypoint: /project/pdo/tools/start_services.sh -m build -c 5 -i localhost -l http://127.0.0.1:6600
+
+  openvino_container:
+    image: openvino/model_server:latest
+    container_name: openvino_container
+    network_mode: "host"
+    volumes:
+      - ./models/:/models/
+    command: --model_path /models/ --model_name resnet --port 9000 --shape auto --grpc_bind_address 127.0.0.1
+
+  guardian_container:
+    image: pdo_contracts:${CONTRACTS_VERSION}
+    container_name: guardian_container
+    depends_on:
+      - services_container
+      - openvino_container
+    network_mode: "host"
+    volumes:
+      - ./xfer/:/project/pdo/xfer/
+    entrypoint: /project/pdo/tools/run_guardian_tests.sh -i localhost -l http://127.0.0.1:6600
+
+  container_1:
+    image: pdo_contracts:${CONTRACTS_VERSION}
+    container_name: container_1
+    depends_on:
+      - services_container
+      - openvino_container
+      - guardian_container
+    network_mode: "host"
+    volumes:
+      - ./xfer/:/project/pdo/xfer/
+    entrypoint: /project/pdo/tools/run_jupyter_tests.sh -i localhost -l http://127.0.0.1:6600 -s localhost -p 8888
+
+  container_2:
+    image: pdo_contracts:${CONTRACTS_VERSION}
+    container_name: container_2
+    depends_on:
+      - services_container
+      - openvino_container
+      - guardian_container
+    network_mode: "host"
+    volumes:
+      - ./xfer/:/project/pdo/xfer/
+    entrypoint: /project/pdo/tools/run_jupyter_tests.sh -i localhost -l http://127.0.0.1:6600 -s localhost -p 8887
+
+  container_3:
+    image: pdo_contracts:${CONTRACTS_VERSION}
+    container_name: container_3
+    depends_on:
+      - services_container
+      - openvino_container
+      - guardian_container
+    network_mode: "host"
+    volumes:
+      - ./xfer/:/project/pdo/xfer/
+    entrypoint: /project/pdo/tools/run_jupyter_tests.sh -i localhost -l http://127.0.0.1:6600 -s localhost -p 8886

--- a/exchange-contract/pdo/contracts/common_widgets.py
+++ b/exchange-contract/pdo/contracts/common_widgets.py
@@ -1,0 +1,64 @@
+# Copyright 2024 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import base64
+import logging
+import os
+
+import ipywidgets
+
+_logger = logging.getLogger(__name__)
+
+# -----------------------------------------------------------------
+# -----------------------------------------------------------------
+class FileDownloadLink(ipywidgets.HTML) :
+    """Create a HTML reference to download a file that is not in the
+    Jupyter server namespace.
+
+    The content of the file is read, base64 encoded and embedded in the
+    address reference. This class can serve as a base class for
+    alternative ways of displaying the link.
+    """
+
+    _address_start_template_ = '<a download="{filename}" href="data:{file_type};base64,{payload}" download>'
+    _label_template_ = '{label}'
+    _address_end_template_ = '</a>'
+
+    _extensions_ = {
+        '.pem' : 'application/x-pem-file',
+        '.pdo' : 'application/json',
+        '.toml' : 'application/toml',
+        '.zip' : 'application/zip',
+    }
+
+    def __init__(self, filename : str, label : str = "Download File") :
+        with open(filename, "rb") as fp :
+            payload = base64.b64encode(fp.read()).decode()
+
+        file_type = self._extensions_.get(os.path.splitext(filename)[1], 'application/octet-stream')
+        template = self._address_start_template_ + self._label_template_ + self._address_end_template_
+
+        parameters = {
+            'file_type' : file_type,
+            'label' : label,
+            'payload' : payload,
+            'filename' : os.path.basename(filename),
+        }
+
+        content = template.format(**parameters)
+        super().__init__(value=content)
+
+class FileDownloadButton(FileDownloadLink) :
+    """Create a Jupyter button for a download link"""
+    _label_template_ = '<button class="p-Widget jupyter-widgets jupyter-button widget-button mod-warning">{label}</button>'

--- a/exchange-contract/pdo/contracts/jupyter.py
+++ b/exchange-contract/pdo/contracts/jupyter.py
@@ -36,9 +36,11 @@ import pdo.client.commands.context as pcontext_cmd
 import pdo.client.commands.contract as pcontract_cmd
 import pdo.client.commands.collection as pcollection_cmd
 
+import pdo.contracts.common as common
 import pdo.contracts.groups as groups
 import pdo.contracts.keys as keys
 import pdo.contracts.services as services
+import pdo.contracts.common_widgets as widgets
 
 _logger = logging.getLogger(__name__)
 
@@ -226,17 +228,27 @@ def export_contract_collection(
 
     data_directory = bindings.get('data', state.get(['Contract', 'DataDirectory']))
     contract_cache = bindings.get('save', os.path.join(data_directory, '__contract_cache__'))
-    export_file = '{}.zip'.format(identifier)
+    export_file = '{}/{}.zip'.format(data_directory, identifier)
 
+    paths += common._base_context_.keys()
     pcollection_cmd.export_contract_collection(context, paths, contract_cache, export_file)
     return export_file
 
 # -----------------------------------------------------------------
 # -----------------------------------------------------------------
-def create_download_link(filename : str, label : str = 'Download File') :
-    """Create HTML display that will download a file"""
-    content = '<a href="{}" download>{}</a>'.format(filename, label)
-    return ip_display.HTML(content)
+def import_contract_collection(
+    state : pbuilder.state.State,
+    bindings : pbuilder.bindings.Bindings,
+    context_file : str,
+    import_file : str) :
+    """Import a contract collection file
+    """
+
+    data_directory = bindings.get('data', state.get(['Contract', 'DataDirectory']))
+    contract_cache = bindings.get('save', os.path.join(data_directory, '__contract_cache__'))
+    context = pcollection_cmd.import_contract_collection(context_file, contract_cache, import_file)
+
+    return context
 
 # -----------------------------------------------------------------
 # Load plugins from the contract families. Each contract family

--- a/exchange-contract/pdo/contracts/keys.py
+++ b/exchange-contract/pdo/contracts/keys.py
@@ -15,11 +15,13 @@
 import functools
 import glob
 import os
+import re
 
 import ipywidgets
 
 import pdo.client.builder as pbuilder
 from pdo.common.keys import ServiceKeys
+from pdo.contracts.common_widgets import FileDownloadLink
 
 __all__ = [
     'build_public_key_map',
@@ -147,7 +149,7 @@ class KeyListWidget(ipywidgets.VBox) :
         result = self.table_header
 
         for k in keys :
-            result += "<tr><td>{}</td><td>{}</td></tr>\n".format(k, key_map[k])
+            result += "<tr><td>{}</td><td>{}</td></tr>\n".format(k, FileDownloadLink(key_map[k], key_map[k]).value)
 
         result += self.table_footer
 
@@ -269,15 +271,17 @@ class GenerateKeyWidget(ipywidgets.VBox) :
         super().__init__([ipywidgets.HBox([self.key, self.generate]), self.feedback])
 
     def clear_widget(self) :
-        self.key.value = ''
         self.feedback.clear_output()
 
     def generate_button_click(self, b) :
         identity = self.key.value
-        if identity and identity.isalnum() :
+        if identity and re.match(r'^\w+$', identity) :
             generate_key_pair(self.state, self.bindings, identity)
-            self.clear_widget()
             with self.feedback : print("keys created for {}".format(identity))
+        else :
+            with self.feedback : print("invalid identity {}".format(identity))
+
+        self.key.value = ''
 
 # -----------------------------------------------------------------
 # -----------------------------------------------------------------
@@ -316,7 +320,7 @@ class UploadKeyWidget(ipywidgets.VBox) :
         """
         self.feedback.clear_output()
 
-        if not self.key_entry.value or not self.key_entry.value.isalnum() :
+        if not self.key_entry.value or not re.match(r'^\w+$', self.key_entry.value) :
             with self.feedback : print("Identity must be alphanumeric")
             return
         if not self.key_file.value :


### PR DESCRIPTION
This PR adds two things:
* A multiuser jupyter test (basically just starts 3 containers each with separate jupyter instanced); allows for testing sharing of contracts between distinct users.
* Better support for moving files into and out of containers; file upload widget, contract import, key download.