### PR TITLE
Jupyter support for multiple, independent users

### DIFF
--- a/exchange-contract/docs/notebooks/factories/token_import.py
+++ b/exchange-contract/docs/notebooks/factories/token_import.py
@@ -1,0 +1,79 @@
+# ---
+# jupyter:
+#   jupytext:
+#     text_representation:
+#       extension: .py
+#       format_name: percent
+#       format_version: '1.3'
+#       jupytext_version: 1.16.1
+#   kernelspec:
+#     display_name: Python 3 (ipykernel)
+#     language: python
+#     name: python3
+# ---
+
+# %% [markdown]
+# *WORK IN PROGRESS*
+# # Token Import Factory
+#
+# Use this notebook to import a token from a contract collection file.
+
+# %%
+import os
+import pdo.contracts.jupyter as pc_jupyter
+import IPython.display as ip_display
+
+pc_jupyter.load_ipython_extension(get_ipython())
+
+# %% [markdown]
+# ## Configure Token Contract
+#
+# This section enables provides details for the token to be imported
+#
+# * token_owner : the identity of the owner of the token
+# * token_class : the name of the token, used to simplify local access
+# * token_name : the name of the minted token that will be imported
+# * token_import_file : the name of the contract collections file for the token
+#
+# Note that the notebook assumes that there is a key file for the identity of the form:
+# `${keys}/${identity}_private.pem`.
+
+# %%
+token_owner = input('Identity to use for interacting with the token: ')
+token_class = input('Class of tokens to import: ')
+token_name = input('Name of the token [token_1]: ') or 'token_1'
+token_import_file = input('Name of the token import file: ')
+# %% [markdown]
+# ### Initialize the PDO Environment
+#
+# Initialize the PDO environment. This assumes that a functional PDO configuration is in place and
+# that the PDO virtual environment has been activated. In particular, ensure that the groups file
+# and eservice database have been configured correctly.
+#
+# For the most part, no modifications should be required below.
+# %%
+common_bindings = {
+    'token_owner' : token_owner,
+    'token_class' : token_class,
+    'token_name' : token_name,
+}
+
+(state, bindings) = pc_jupyter.initialize_environment(token_owner, **common_bindings)
+
+context_file = bindings.expand('${etc}/${token_class}_context.toml')
+token_import_file = bindings.expand(token_import_file)
+_ = pc_jupyter.import_contract_collection(state, bindings, context_file, token_import_file)
+
+# %% [markdown]
+# ## Create the Token
+
+# %%
+instance_parameters = {
+    'token_owner' : token_owner,
+    'token_class' : token_class,
+    'token_name' : token_name,
+    'context_file' : context_file,
+}
+
+instance_file = pc_jupyter.instantiate_notebook_from_template(token_class, 'token', instance_parameters)
+ip_display.display(ip_display.Markdown('[Token {}]({})'.format(instance_parameters['token_name'], instance_file)))

--- a/exchange-contract/docs/notebooks/factories/token_issuer.py
+++ b/exchange-contract/docs/notebooks/factories/token_issuer.py
@@ -56,5 +56,5 @@ instance_parameters = {
     'service_group' : service_group,
 }
 
-instance_file = pc_jupyter.instantiate_notebook_from_template(token_class, 'token-issuer', instance_parameters)
+instance_file = pc_jupyter.instantiate_notebook_from_template(token_class, 'token_issuer', instance_parameters)
 ip_display.display(ip_display.Markdown('[Token Issuer]({})'.format(instance_file)))

--- a/exchange-contract/docs/notebooks/factories/wallet.py
+++ b/exchange-contract/docs/notebooks/factories/wallet.py
@@ -32,14 +32,35 @@ pc_jupyter.load_ipython_extension(get_ipython())
 #
 # * identity : the identity of the token creator
 # * asset_name : the name of tokens that will be generated
-# * context_file : the
+# * asset_import_file : the name of the contract collections file for the asset
 #
-# Note that the notebook assumes that there is a key file for the identity of the form: `${keys}/${identity}_private.pem`.
+# Note that the notebook assumes that there is a key file for the identity of the form:
+# `${keys}/${identity}_private.pem`.
 
 # %%
-identity = input('Identity of the wallet owner: ')
-asset_name = input('Name of the asset:')
-context_file = input('Path to the contract context file')
+wallet_owner = input('Identity of the wallet owner: ')
+asset_name = input('Name of the asset: ')
+import_file = input('Name of the asset import file: ')
+
+# %% [markdown]
+# ### Initialize the PDO Environment
+#
+# Initialize the PDO environment. This assumes that a functional PDO configuration is in place and
+# that the PDO virtual environment has been activated. In particular, ensure that the groups file
+# and eservice database have been configured correctly.
+#
+# For the most part, no modifications should be required below.
+# %%
+common_bindings = {
+    'wallet_owner' : wallet_owner,
+    'asset_name' : asset_name,
+}
+
+(state, bindings) = pc_jupyter.initialize_environment(wallet_owner, **common_bindings)
+
+context_file = bindings.expand('${etc}/${asset_name}_context.toml')
+import_file = bindings.expand(import_file)
+_ = pc_jupyter.import_contract_collection(state, bindings, context_file, import_file)
 
 # %% [markdown]
 # ## Create the Wallet Notebook
@@ -47,12 +68,12 @@ context_file = input('Path to the contract context file')
 # Create a new wallet notebook with the specific asset identified.
 
 # %%
-parameters = {
-    'identity' : identity,
+instance_parameters = {
+    'wallet_owner' : wallet_owner,
     'asset_name' : asset_name,
     'context_file' : context_file,
 }
 
-instance_file = pc_jupyter.instantiate_notebook_from_template(asset_name, 'wallet', parameters)
+instance_file = pc_jupyter.instantiate_notebook_from_template(asset_name, 'wallet', instance_parameters)
 ip_display.display(ip_display.Markdown('[Wallet]({})'.format(instance_file)))
 # %%

--- a/exchange-contract/docs/notebooks/templates/exchange_create.py
+++ b/exchange-contract/docs/notebooks/templates/exchange_create.py
@@ -237,7 +237,7 @@ contract_files = {
 # %%
 # %%skip True
 export_file = pc_jupyter.export_contract_collection(state, bindings, context, contexts, contract_identifier)
-ip_display.display(pc_jupyter.create_download_link(export_file, 'Download Contract Collection File'))
+ip_display.display(pc_jupyter.widgets.FileDownloadButton(export_file, 'Download Contract'))
 
 # %% [markdown]
 # <hr style="border:2px solid gray">

--- a/exchange-contract/docs/notebooks/templates/issuer.py
+++ b/exchange-contract/docs/notebooks/templates/issuer.py
@@ -197,7 +197,7 @@ contract_files = {
 # %%
 # %%skip True
 export_file = pc_jupyter.export_contract_collection(state, bindings, context, contexts, contract_identifier)
-ip_display.display(pc_jupyter.create_download_link(export_file, 'Download Contract Collection File'))
+ip_display.display(pc_jupyter.widgets.FileDownloadButton(export_file, 'Download Contract'))
 
 # %% [markdown]
 # <hr style="border:2px solid gray">

--- a/exchange-contract/docs/notebooks/templates/token.py
+++ b/exchange-contract/docs/notebooks/templates/token.py
@@ -25,18 +25,11 @@
 # * token_path : the full context path to the token
 # * context_file : the name of the context file where token information is located
 #
-# Note that the notebook assumes that there is a key file for the identity of the form
-#
-# ```bash
-# ${keys}/${identity}_private.pem
-# ```
-#
 
 # %% tags=["parameters"]
 token_owner = 'user1'
 token_class = 'mytoken'
 token_name = 'token_1'
-token_path = 'token.${token_class}.token_object.${token_name}'
 context_file = '${etc}/${token_class}_context.toml'
 instance_identifier = ''
 
@@ -60,13 +53,16 @@ pc_jupyter.load_ipython_extension(get_ipython())
 #
 # For the most part, no modifications should be required below.
 # %%
-common_bindings = {
-    'token_owner' : token_owner,
-    'token_class' : token_class,
-    'token_name' : token_name,
-}
+try : state
+except NameError :
+    common_bindings = {
+        'token_owner' : token_owner,
+        'token_class' : token_class,
+        'token_name' : token_name,
+    }
 
-(state, bindings) = pc_jupyter.initialize_environment(token_owner, **common_bindings)
+    (state, bindings) = pc_jupyter.initialize_environment(token_owner, **common_bindings)
+
 print('environment initialized')
 
 # %% [markdown]
@@ -81,7 +77,6 @@ print('environment initialized')
 # For the most part, no other modifications should be required.
 
 # %%
-token_class_path = 'token.' + token_class
 context_file = bindings.expand(context_file)
 print("using context file {}".format(context_file))
 
@@ -89,6 +84,7 @@ context_bindings = {
     'identity' : token_owner,
 }
 
+token_class_path = 'token.' + token_class
 context = pc_jupyter.ex_jupyter.initialize_token_context(
     state, bindings, context_file, token_class_path, **context_bindings)
 print('context initialized')
@@ -99,6 +95,7 @@ print('context initialized')
 # ## Operate on the Token Contract
 
 # %%
+token_path = '{}.token_object.{}'.format(token_class_path, token_name)
 token_context = pc_jupyter.pbuilder.Context(state, token_path)
 
 # %% [markdown]
@@ -108,16 +105,18 @@ token_context = pc_jupyter.pbuilder.Context(state, token_path)
 def token_echo(message) :
     return pc_jupyter.pcommand.invoke_contract_cmd(
         pc_jupyter.ex_token_object.cmd_echo, state, token_context, message=message)
-
-# token_echo('hello from token {}'.format(token_path))
+# %%
+# %%skip True
+token_echo('hello from token {}'.format(token_path))
 # %% [markdown]
 # ### Transfer Ownership
 # %%
 def token_transfer(new_owner) :
     return pc_jupyter.pcommand.invoke_contract_cmd(
         pc_jupyter.ex_issuer.cmd_transfer_assets, state, token_context, new_owner=new_owner)
-
-# token_transfer('user2')
+# %%
+# %%skip True
+token_transfer('user2')
 # %% [markdown]
 # <hr style="border:2px solid gray">
 #
@@ -145,7 +144,7 @@ contract_files = {
 # %%
 # %%skip True
 export_file = pc_jupyter.export_contract_collection(state, bindings, context, contexts, contract_identifier)
-ip_display.display(pc_jupyter.create_download_link(export_file, 'Download Contract Collection File'))
+ip_display.display(pc_jupyter.widgets.FileDownloadButton(export_file, 'Download Contract'))
 
 # %% [markdown]
 # <hr style="border:2px solid gray">

--- a/exchange-contract/docs/notebooks/templates/token_issuer.py
+++ b/exchange-contract/docs/notebooks/templates/token_issuer.py
@@ -19,16 +19,20 @@
 # %% [markdown]
 # ## Configure Token Information
 #
-# This section enables customization of the token that will be minted. Edit the variables in the section below as necessary.
+# This section enables customization of the token that will be minted. Edit the variables in the
+# section below as necessary.
 #
 # * identity : the identity of the token creator
-# * service_host : the host for the eservice where tokens will be minted, this will use the default service group
-# * token_class : the name of tokens that will be generated, this is only used to simplify local access (e.g. context file name)
+# * service_host : the host for the eservice where tokens will be minted, this will use the default
+#   service group
+# * token_class : the name of tokens that will be generated, this is only used to simplify local
+#   access (e.g. context file name)
 # * token_description : a description of the asset associated with the minted tokens
 # * token_metadata : additional information about the token
 # * count : the number of tokens to mint for the asset
 #
-# Note that the notebook assumes that there is a key file for the identity of the form: `${keys}/${identity}_private.pem`.
+# Note that the notebook assumes that there is a key file for the identity of the form:
+# `${keys}/${identity}_private.pem`.
 
 # %% tags=["parameters"]
 token_owner = 'user1'
@@ -73,12 +77,14 @@ print('environment initialized')
 # %% [markdown]
 # ### Initialize the Contract Context
 #
-# The contract context defines the configuration for a collection of contract objects that interact with one another. By default, the context file used in this notebook is specific to the token. If you prefer to use a common context file, edit the `context_file` variable below.
+# The contract context defines the configuration for a collection of contract objects that interact
+# with one another. By default, the context file used in this notebook is specific to the token. If
+# you prefer to use a common context file, edit the `context_file` variable below.
 #
 # For the most part, no other modifications should be required.
 
 # %%
-token_path = 'token.' + token_class
+token_class_path = 'token.' + token_class
 context_file = bindings.expand('${etc}/${token_class}_context.toml')
 print("using context file {}".format(context_file))
 
@@ -90,22 +96,25 @@ context_bindings = {
     'token_issuer.token_metadata.opaque' : token_metadata,
 }
 
-context = pc_jupyter.ex_jupyter.initialize_token_context(state, bindings, context_file, token_path, **context_bindings)
-pc_jupyter.pbuilder.Context.SaveContextFile(state, context_file, prefix=token_path)
+context = pc_jupyter.ex_jupyter.initialize_token_context(state, bindings, context_file, token_class_path, **context_bindings)
+pc_jupyter.pbuilder.Context.SaveContextFile(state, context_file, prefix=token_class_path)
 print('context initialized')
 
 # %% [markdown]
 # ### Create the Token Issuer Contract
 #
-# The process of creating the token issuer will also create an asset type contract object, a vetting organization contract object, and the guardian contract object. The asset type and vetting organization contract objects are principally used to complete the canonical asset interface that enables transparent value exchanges with tokens and other digital assets.
+# The process of creating the token issuer will also create an asset type contract object, a vetting
+# organization contract object, and the guardian contract object. The asset type and vetting
+# organization contract objects are principally used to complete the canonical asset interface that
+# enables transparent value exchanges with tokens and other digital assets.
 
 # %%
-token_issuer_context = pc_jupyter.pbuilder.Context(state, token_path + '.token_issuer')
+token_issuer_context = pc_jupyter.pbuilder.Context(state, token_class_path + '.token_issuer')
 token_issuer_save_file = token_issuer_context.get('save_file')
 if not token_issuer_save_file :
     token_issuer_save_file = pc_jupyter.pcommand.invoke_contract_cmd(
         pc_jupyter.ex_token_issuer.cmd_create_token_issuer, state, token_issuer_context)
-    pc_jupyter.pbuilder.Context.SaveContextFile(state, context_file, prefix=token_path)
+    pc_jupyter.pbuilder.Context.SaveContextFile(state, context_file, prefix=token_class_path)
 print('token issuer contract in {}'.format(token_issuer_save_file))
 
 # %% [markdown]
@@ -117,11 +126,11 @@ print('token issuer contract in {}'.format(token_issuer_save_file))
 # ### Mint the Tokens
 
 # %%
-token_object_context = pc_jupyter.pbuilder.Context(state, token_path + '.token_object')
+token_object_context = pc_jupyter.pbuilder.Context(state, token_class_path + '.token_object')
 
 minted_token_save_files = pc_jupyter.pcommand.invoke_contract_cmd(
     pc_jupyter.ex_token_object.cmd_mint_tokens, state, token_object_context)
-pc_jupyter.pbuilder.Context.SaveContextFile(state, context_file, prefix=token_path)
+pc_jupyter.pbuilder.Context.SaveContextFile(state, context_file, prefix=token_class_path)
 
 minted_token_contexts = []
 for token_index in range(1, len(minted_token_save_files)+1) :
@@ -144,7 +153,6 @@ parameters = {
 }
 
 for token_context in minted_token_contexts :
-    parameters['token_path'] = token_context.path
     parameters['token_name'] = token_context.path.split('.')[-1]
 
     instance_file = pc_jupyter.instantiate_notebook_from_template(token_class, 'token', parameters)
@@ -179,7 +187,7 @@ contract_files = {
 # %%
 # %%skip True
 export_file = pc_jupyter.export_contract_collection(state, bindings, context, contexts, contract_identifier)
-ip_display.display(pc_jupyter.create_download_link(export_file, 'Download Contract Collection File'))
+ip_display.display(pc_jupyter.widgets.FileDownloadButton(export_file, 'Download Contract'))
 
 # %% [markdown]
 # <hr style="border:2px solid gray">

--- a/exchange-contract/docs/tests/05.token_transfer.md
+++ b/exchange-contract/docs/tests/05.token_transfer.md
@@ -1,0 +1,110 @@
+<!---
+Licensed under Creative Commons Attribution 4.0 International License
+https://creativecommons.org/licenses/by/4.0/
+--->
+
+# Verify Token Transfer #
+
+## Goal ##
+
+This scenario uses issued tokens as a means of testing multi-user
+scenarios. The intent is that a contract can be created by one
+identity and transferred to another running in a completely separated
+environment. The test uses two separate docker containers to simulate
+to distinct user environments. Token transfer is used to leverage the
+existance of the token notebook that is independent of all contract
+creation operations making it easier to import an existing contract.
+
+## Setup ##
+
+**Prepare the multiuser Jupyter docker test.** To start the services,
+run `make -C docker test_multiuser_jupyter` from the PDO contracts
+root directory. When the services start the two Jupyter containers
+(`container_1` and `container_2`) will show the access URLs. Open each
+URL in a separate browser window. For the rest of this discussion, we
+will refer to the windows as `container_1` (for the user) and
+`container_2` (for the issuer).
+
+**Container_1: Create the keys for the token user.** Open the
+notebook `documents/getting_started.ipynb` and run all cells. Navigate
+to "Create Keys" and create a new key pair for the identity
+"blue_user". Refresh the list of public keys and click on the
+"blue_user" key file to download the "blue_user" public key.
+
+**Container_2: Create the keys for the token issuer.** Open the
+notebook `documents/getting_started.ipynb` and run all cells. Navigate
+to "Create Keys" and create a new key pair for the identity
+"blue_issuer". Refresh the public and private key lists to verify
+that the keys have been created.
+
+**Container_2: Import the "blue_user" public key into the issuer.**
+Navigate to the "Create Keys" section and import the the "blue_user"
+public key that was downloaded earlier. Refresh the public key list to
+verify that the key was uploaded successfully.
+
+**Container_2: Create the service group.** Navigate to "Create Service
+Group" and create a new three new service groups, one each for the
+enclave, provisioning and storage services (select each of the tabs
+separately). Select the first three services of each type for each
+group. Call each of the groups "issuer_group". For the storage
+service group, set the required duration to 3600. Refresh each of the
+group lists to verify that the groups have been created.
+
+## Test ##
+
+**Container_2: Create the token issuer and the tokens.** From the
+launcher open the notebook in
+`exchange/factories/token_issuer.ipynb`. Run all cells. Respond to the
+prompts as follows:
+
+* Identity: `blue_issuer`
+* Name of the token class: `blue_widget`
+* Token description: `my token`
+* Count: 5
+* Service group: `issuer_group`
+
+This will create a link to a token issuer notebook. Click on the link
+to open the token issuer notebook. Run all cells. You can verify that
+the tokens were correctly created in the "Mint the Tokens"
+section. The last line in the output should say "5 tokens minted".
+
+In the "Create Token Notebooks" section, edit the code block and
+replace `%%skip True` with `%%skip False`. Then run the cell to
+generate a new notebook for each of the tokens. There should be five
+links in the output section, each labelled with the token's name.
+
+Click on "Token token_1" to open the `token_1` notebook. Run all
+cells. To verify that the notebook is correct, in the "Invoke Echo
+Operation" section, change `%%skip True` to `%%skip False` and run the
+cell. The output should contain the string parameter from the
+invocation.
+
+In the "Transfer Ownership" section, change `%%skip True` to `%%skip
+False` and change `user2` to `blue_user`. Run the cell. The output
+should indicate that the token has been transferred.
+
+In the "Share Contract" section, change `%%skip True` to `%%skip
+False` and run the cell. This should create a "Download Contract"
+button. Click the button and save the contract collection file.
+
+**Shell: Move the contract collection file.** Move the contract
+collection file downloaded in the previous step into the
+`docker/xfer/client` directory where you are running to contracts
+docker containers. The name of the file will be something like
+`blue_widget_<ID>.zip` where ID is a unique identifier for the
+contract.
+
+**Container_1: Import and run the token contract.** From the launcher
+open the notebook in `exchange/factories/token_import.ipynb`. Run all
+cells. Repond to the prompts as follows:
+
+* Identity: `blue_user`
+* Name of the token class: `blue_widget`
+* Name of the token: `token_1`
+* Name of the token import file: `/project/pdo/xfer/client/blue_widget_<ID>.zip`
+
+This will create a link to a token notebook. Click on the link to
+open the notebook. Run all cells. To verify that the notebook is
+correct, in the "Invoke Echo Operation" section, change `%%skip True`
+to `%%skip False` and run the cell. The output should contain the
+string parameter from the invocation.

--- a/exchange-contract/docs/tests/06.single_issuer_wallet.md
+++ b/exchange-contract/docs/tests/06.single_issuer_wallet.md
@@ -1,0 +1,99 @@
+<!---
+Licensed under Creative Commons Attribution 4.0 International License
+https://creativecommons.org/licenses/by/4.0/
+--->
+
+# Single Issuer Wallet #
+
+## Goal ##
+
+This scenarios tests the separation of issuer and user operations on
+issued assets. A user, running in an environment distinct from the
+issuer, will create a digital wallet for a specific issued asset. The
+wallet will allow queries for asset balance and simple transfer of
+assets to another user.
+
+## Setup ##
+
+**Prepare the multiuser Jupyter docker test.** To start the services,
+run `make -C docker test_multiuser_jupyter` from the PDO contracts
+root directory. When the services start, the two Jupyter containers
+(`container_1` and `container_2`) will show the access URLs. Open each
+URL in a separate browser window. For the rest of this discussion, we
+will refer to the windows as `container_1` (for the user) and
+`container_2` (for the issuer).
+
+**Container_1: Create the keys for the user.** Open the notebook
+`documents/getting_started.ipynb` and run all cells. Navigate to
+"Create Keys" and create a new key pair for the identity
+"blue_user". Refresh the list of public keys and click on the
+"blue_user" key file to download the "blue_user" public key.
+
+**Container_2: Create the keys for the issuer.** Open the
+notebook `documents/getting_started.ipynb` and run all cells. Navigate
+to "Create Keys" and create a new key pair for the identity
+"blue_issuer". Refresh the public and private key lists to verify
+that the keys have been created.
+
+**Container_2: Import the "blue_user" public key into the issuer.**
+Navigate to the "Create Keys" section and import the the "blue_user"
+public key that was downloaded earlier. Refresh the public key list to
+verify that the key was uploaded successfully.
+
+**Container_2: Create the service group.** Navigate to "Create Service
+Group" and create a new three new service groups, one each for the
+enclave, provisioning and storage services (select each of the tabs
+separately). Select the first three services of each type for each
+group. Call each of the groups "issuer_group". For the storage
+service group, set the required duration to 3600. Refresh each of the
+group lists to verify that the groups have been created.
+
+## Test ##
+
+**Container_2: Create the issuer and issue assets.** From the
+launcher open the notebook in
+`exchange/factories/issuer.ipynb`. Run all cells. Respond to the
+prompts as follows:
+
+* Identity: `blue_issuer`
+* Name of the asset class: `blue_marble`
+* Asset description: `blue marbles`
+* Link to more information: `http://`
+* Service group: `issuer_group`
+
+This will create a link to a issuer notebook. Click on the link to
+open the issuer notebook. Run all cells. You can verify that the
+issuer was created successfully by looking in the "Approve Authority
+Chain" section; the output should say that the issuer was successfully
+initialized.
+
+In the "Issue Assets" section of the issuer contract, change `%%skip
+True` to `%%skip False` and change `user1` to `blue_user`. Run the
+cell. The output should indicate that 50 assets were issued to
+`blue_user`.
+
+In the "Share Contract" section, change `%%skip True` to `%%skip
+False` and run the cell. This should create a "Download Contract"
+button. Click the button and save the contract collection file.
+
+**Shell: Move the contract collection file.** Move the contract
+collection file downloaded in the previous step into the
+`docker/xfer/client` directory where you are running to contracts
+docker containers. The name of the file will be something like
+`blue_marble_<ID>.zip` where ID is a unique identifier for the
+contract.
+
+**Container_1: Import the issuer contract and create a wallet.** From the launcher
+open the notebook in `exchange/factories/wallet.ipynb`. Run all
+cells. Repond to the prompts as follows:
+
+* Identity: `blue_user`
+* Name of the asset: `blue_marble`
+* Name of the issuer import file: `/project/pdo/xfer/client/blue_marble_<ID>.zip`
+
+This will create a link to the wallet notebook. Click on the link to
+open the notebook. Run all cells. To verify that the notebook is
+correct, get the balance of the current issuance. This can be done in
+the "Get the Account Balance" section by changing the `%%skip True` to
+`%%skip False`. When run, the output should say that the balance is
+currently 50 blue marbles.

--- a/exchange-contract/docs/tests/07.multiple_issuer_wallet.md
+++ b/exchange-contract/docs/tests/07.multiple_issuer_wallet.md
@@ -1,0 +1,123 @@
+<!---
+Licensed under Creative Commons Attribution 4.0 International License
+https://creativecommons.org/licenses/by/4.0/
+--->
+
+# Multiple Issuer Wallet #
+
+## Goal ##
+
+This scenarios tests wallets that contain assets from more than
+one issuer.
+
+## Setup ##
+
+**Prepare the multiuser Jupyter docker test.** To start the services,
+run `make -C docker test_multiuser_jupyter` from the PDO contracts
+root directory. When the services start, the two Jupyter containers
+(`container_1` and `container_2`) will show the access URLs. Open each
+URL in a separate browser window. For the rest of this discussion, we
+will refer to the windows as `container_1` (for the user) and
+`container_2` (for the issuer).
+
+**Container_1: Create the keys for the user.** Open the notebook
+`documents/getting_started.ipynb` and run all cells. Navigate to
+"Create Keys" and create a new key pair for the identity
+"alice". Refresh the list of public keys and click on the
+"alice" key file to download the "alice" public key.
+
+**Container_2: Create the keys for the issuer.** Open the notebook
+`documents/getting_started.ipynb` and run all cells. Navigate to
+"Create Keys" and create a new key pair for the identity
+"blue_issuer". Using the same steps, create a new key pair for the
+identity "green_issuer". Refresh the public and private key lists to
+verify that the keys have been created.
+
+**Container_2: Import the "alice" public key into the issuer.**
+Navigate to the "Create Keys" section and import the the "alice"
+public key that was downloaded earlier. Refresh the public key list to
+verify that the key was uploaded successfully.
+
+**Container_2: Create the service group.** Navigate to "Create Service
+Group" and create a new three new service groups, one each for the
+enclave, provisioning and storage services (select each of the tabs
+separately). Select the first three services of each type for each
+group. Call each of the groups "issuer_group". For the storage
+service group, set the required duration to 3600. Refresh each of the
+group lists to verify that the groups have been created.
+
+## Test ##
+
+**Container_2: Create the blue issuer and issue assets.** From the
+launcher open the notebook in
+`exchange/factories/issuer.ipynb`. Run all cells. Respond to the
+prompts as follows:
+
+* Identity: `blue_issuer`
+* Name of the asset class: `blue_marble`
+* Asset description: `blue marbles`
+* Link to more information: `http://`
+* Service group: `issuer_group`
+
+This will create a link to a issuer notebook. Click on the link to
+open the issuer notebook. Run all cells. You can verify that the
+issuer was created successfully by looking in the "Approve Authority
+Chain" section; the output should say that the issuer was successfully
+initialized.
+
+In the "Issue Assets" section of the issuer contract, change `%%skip
+True` to `%%skip False` and change `user1` to `alice`. Run the
+cell. The output should indicate that 50 assets were issued to
+`alice`.
+
+In the "Share Contract" section, change `%%skip True` to `%%skip
+False` and run the cell. This should create a "Download Contract"
+button. Click the button and save the contract collection file.
+
+**Container_2: Create the green issuer and issue assets.** From the
+launcher open the notebook in
+`exchange/factories/issuer.ipynb`. Run all cells. Respond to the
+prompts as follows:
+
+* Identity: `green_issuer`
+* Name of the asset class: `green_marble`
+* Asset description: `green marbles`
+* Link to more information: `http://`
+* Service group: `issuer_group`
+
+This will create a link to a issuer notebook. Click on the link to
+open the issuer notebook. Run all cells. You can verify that the
+issuer was created successfully by looking in the "Approve Authority
+Chain" section; the output should say that the issuer was successfully
+initialized.
+
+In the "Issue Assets" section of the issuer contract, change `%%skip
+True` to `%%skip False` and change `user1` to `alice`. Run the
+cell. The output should indicate that 50 assets were issued to
+`alice`.
+
+In the "Share Contract" section, change `%%skip True` to `%%skip
+False` and run the cell. This should create a "Download Contract"
+button. Click the button and save the contract collection file.
+
+**Shell: Move the contract collection files.** Move the contract
+collection files that were downloaded in the previous step into the
+`docker/xfer/client` directory where you are running to contracts
+docker containers. The name of the file will be something like
+`blue_marble_<ID>.zip` and `green_marble_<ID>.zip` where ID is a
+unique identifier for the contract.
+
+**Container_1: Import the issuer contract and create a wallet.** From the launcher
+open the notebook in `exchange/factories/wallet.ipynb`. Run all
+cells. Repond to the prompts as follows:
+
+* Identity: `alice`
+* Name of the asset: `blue_marble`
+* Name of the issuer import file: `/project/pdo/xfer/client/blue_marble_<ID>.zip`
+
+This will create a link to the wallet notebook. Click on the link to
+open the notebook. Run all cells. To verify that the notebook is
+correct, get the balance of the current issuance. This can be done in
+the "Get the Account Balance" section by changing the `%%skip True` to
+`%%skip False`. When run, the output should say that the balance is
+currently 50 blue marbles.


### PR DESCRIPTION
Adds Jupyter support for multiple independent users to share token and issuer contracts. 
First basic implementation of a wallet for a single issuer
Scenarios for testing (05 and 06 should work, 07 is future work)
