### PR TITLE
Fix numpy version to 1.24.4 for use within Inference contract guardian.

### DIFF
--- a/inference-contract/setup.py
+++ b/inference-contract/setup.py
@@ -88,6 +88,7 @@ setup(
         'twisted',
         'jsonschema>=3.0.1',
         'futures==3.1.1',
+        'numpy==1.24.4',
         'opencv-python>=4.6.0',
         'tensorflow-serving-api==2.11.0',
         'pdo-client>=' + pdo_client_version,


### PR DESCRIPTION
Before this PR, numpy was autoinstalled as part of opencv installation. At the time of this PR, opencv attempts to install numpy 2.0.0, and this is not consistent with the rest of the guardian code. This change fixes the recent guardian failures that were being seen due to the numpy dependency issue.

