### PR TITLE
add handlers that simplify error display for internal functions

### DIFF
--- a/exchange-contract/exchange/common/Common.h
+++ b/exchange-contract/exchange/common/Common.h
@@ -20,6 +20,28 @@
 #include "Message.h"
 #include "Types.h"
 #include "Value.h"
+#include "WasmExtensions.h"
+
+#define ERROR_IF_NULL(_ptr_, _message_, ...)            \
+    if ((_ptr_) == NULL)                                \
+    {                                                   \
+        CONTRACT_SAFE_LOG(3, _message_, ##__VA_ARGS__); \
+        return false;                                   \
+    }
+
+#define ERROR_IF(_condition_, _message_, ...)           \
+    if (_condition_)                                    \
+    {                                                   \
+        CONTRACT_SAFE_LOG(3, _message_, ##__VA_ARGS__); \
+        return false;                                   \
+    }
+
+#define ERROR_IF_NOT(_condition_, _message_, ...)       \
+    if (! (_condition_))                                \
+    {                                                   \
+        CONTRACT_SAFE_LOG(3, _message_, ##__VA_ARGS__); \
+        return false;                                   \
+    }
 
 namespace ww
 {


### PR DESCRIPTION
ERROR_IF, ERROR_IF_NULL, ERROR_IF_NOT macros that display an error message and return false. Comparable to the ASSERT macros for final contract response.

Would be a LOT easier with exceptions.