### PR TITLE
Add token object function for retrieving the token metadata

### DIFF
--- a/exchange-contract/exchange/contracts/token_object.cpp
+++ b/exchange-contract/exchange/contracts/token_object.cpp
@@ -65,7 +65,7 @@ bool ww::exchange::token_object::get_token_metadata(
 
     ww::value::Object deserialized_token_metadata;
     ERROR_IF_NOT(deserialized_token_metadata.deserialize(serialized_token_metadata.c_str()),
-                 "unexpected error: failed to deserialized token metadata");
+                 "unexpected error: failed to deserialize token metadata");
 
     ww::value::Object token_metadata_schema;
     ERROR_IF_NOT(token_metadata_schema.deserialize(schema.c_str()),

--- a/exchange-contract/exchange/token_object.h
+++ b/exchange-contract/exchange/token_object.h
@@ -76,6 +76,10 @@ namespace token_object
         const ww::value::Object& parameters,
         ww::value::Object& capability_result);
 
+    bool get_token_metadata(
+        const std::string& schema,
+        ww::value::Object& token_metadata);
+
 }; // token_object
 }; // exchange
 }; // ww


### PR DESCRIPTION
Token metadata is passed from the token issuer to the token object. This is intended to enable secret provisioning of the token objects (e.g. to push a configure count of operations or configuration of output processing for inference). This commit makes the opaque data easier to access by contract objects that inherit methods from token_object.