### PR TITLE
add simple capability for at-most-once capabilities in the guardian

### DIFF
--- a/common-contract/pdo/contracts/guardian/common/guardian_service.py
+++ b/common-contract/pdo/contracts/guardian/common/guardian_service.py
@@ -92,10 +92,10 @@ class GuardianServiceClient(GenericServiceClient) :
                 return response.json()
 
         except requests.HTTPError as he :
-            logger.warn('HTTP error [%s]; %s, %s', path, he.response.status_code, he.response.text.strip())
+            logger.warning('HTTP error [%s]; %s, %s', path, he.response.status_code, he.response.text.strip())
             raise MessageException(f'HTTP error [{he.response.status_code}]: {he.response.text.strip()}') from he
         except (requests.ConnectionError, requests.Timeout) as e :
-            logger.warn('network error connecting to service (%s); %s', path, str(e))
+            logger.warning('network error connecting to service (%s); %s', path, str(e))
             raise MessageException(str(e)) from e
 
     # -----------------------------------------------------------------

--- a/common-contract/pdo/contracts/guardian/common/guardian_service.py
+++ b/common-contract/pdo/contracts/guardian/common/guardian_service.py
@@ -91,7 +91,10 @@ class GuardianServiceClient(GenericServiceClient) :
                 response.raise_for_status()
                 return response.json()
 
-        except (requests.HTTPError, requests.ConnectionError, requests.Timeout) as e :
+        except requests.HTTPError as he :
+            logger.warn('HTTP error [%s]; %s, %s', path, he.response.status_code, he.response.text.strip())
+            raise MessageException(f'HTTP error [{he.response.status_code}]: {he.response.text.strip()}') from he
+        except (requests.ConnectionError, requests.Timeout) as e :
             logger.warn('network error connecting to service (%s); %s', path, str(e))
             raise MessageException(str(e)) from e
 
@@ -111,7 +114,10 @@ class GuardianServiceClient(GenericServiceClient) :
                 response.raise_for_status()
                 return response.json()
 
-        except (requests.HTTPError, requests.ConnectionError, requests.Timeout) as e :
+        except requests.HTTPError as he :
+            logger.warn('HTTP error [%s]; %s, %s', path, he.response.status_code, he.response.text.strip())
+            raise MessageException(f'HTTP error [{he.response.status_code}]: {he.response.text.strip()}') from he
+        except (requests.ConnectionError, requests.Timeout) as e :
             logger.warn('network error connecting to service (%s); %s', path, str(e))
             raise MessageException(str(e)) from e
 

--- a/common-contract/pdo/contracts/guardian/scripts/guardianCLI.py
+++ b/common-contract/pdo/contracts/guardian/scripts/guardianCLI.py
@@ -47,29 +47,6 @@ from twisted.internet import reactor, defer
 from twisted.internet.endpoints import TCP4ServerEndpoint
 from twisted.web.wsgi import WSGIResource
 
-## ----------------------------------------------------------------
-def ErrorResponse(request, error_code, msg) :
-    """Generate a common error response for broken requests
-    """
-
-    result = ""
-    if request.method != 'HEAD' :
-        result = msg + '\n'
-        result = result.encode('utf8')
-
-    request.setResponseCode(error_code)
-    request.setHeader(b'Content-Type', b'text/plain')
-    request.setHeader(b'Content-Length', len(result))
-    request.write(result)
-
-    try :
-        request.finish()
-    except :
-        logger.exception("exception during request finish")
-        raise
-
-    return request
-
 # -----------------------------------------------------------------
 # -----------------------------------------------------------------
 def __shutdown__(*args) :

--- a/exchange-contract/exchange/token_object.h
+++ b/exchange-contract/exchange/token_object.h
@@ -48,6 +48,7 @@
 #define TO_OPERATION_SCHEMA                     \
     "{"                                         \
         SCHEMA_KW(nonce,"") ","                 \
+        SCHEMA_KW(request_identifier,"") ","    \
         SCHEMA_KW(method_name, "") ","          \
         SCHEMA_KWS(parameters, "{}")            \
     "}"
@@ -71,6 +72,13 @@ namespace token_object
 
     // utility functions
     bool initialize_contract(const Environment& env);
+
+    bool create_operation_package(
+        const std::string& request_identifier,
+        const std::string& method_name,
+        const ww::value::Object& parameters,
+        ww::value::Object& capability_result);
+
     bool create_operation_package(
         const std::string& method_name,
         const ww::value::Object& parameters,
@@ -79,6 +87,9 @@ namespace token_object
     bool get_token_metadata(
         const std::string& schema,
         ww::value::Object& token_metadata);
+
+    bool get_token_identity(
+        std::string& token_identity);
 
 }; // token_object
 }; // exchange


### PR DESCRIPTION
- Refined error responses in guardian service and process capability apps
- Added support for request uniqueness checks in guardian operations
- Introduced `request_identifier` field to ensure unique operation requests
- Implemented a method to retrieve token identity in exchange token object
- Extended `create_operation_package` to include `request_identifier` handling

This is a very simple implementation of at-most-once semantics for guardian capability processing. To use the feature, add a property to the guardian capability handler class: "unique_request = True".  This implementation uses an in memory set on a per-token basis. The implemmentation uses the token identity property that is part of the token-guardian protocol. Added a method to expose the token identity value from the base token_object method class.